### PR TITLE
Change Piwik to Matamo

### DIFF
--- a/fragdenstaat_de/theme/templates/footer.html
+++ b/fragdenstaat_de/theme/templates/footer.html
@@ -75,7 +75,7 @@
   <div class="row small">
     <div class="col-lg-12">
       <p>
-        Fragdenstaat nutzt statt den üblichen externen Dienstleistern die datenschutzfreundlichere Technologie von <a href="https://piwik.org/">Piwik</a>, um statistische Auswertungen der Seitennutzung zu erhalten. Wenn sie dies nicht wollen, <a href="https://traffic.okfn.de/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=de">klicken Sie bitte hier und entfernen Sie den Haken</a>. Näheres in <a href="{% url 'help-privacy' %}">unserer Datenschutzerklärung</a>.
+        Fragdenstaat nutzt statt den üblichen externen Dienstleistern die datenschutzfreundlichere Technologie von <a href="https://matomo.org">Matamo</a>, um statistische Auswertungen der Seitennutzung zu erhalten. Wenn sie dies nicht wollen, <a href="https://traffic.okfn.de/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=de">klicken Sie bitte hier und entfernen Sie den Haken</a>. Näheres in <a href="{% url 'help-privacy' %}">unserer Datenschutzerklärung</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Piwik changed the name to Matamo and as I see, you already updated piwik to matamo

But some pages should also change the name: 
- [ ] https://fragdenstaat.de/hilfe/howto/datenschutzerklaerung/