### PR TITLE
Fix docker-compose build by installing libgeos-c1v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DJANGO_SETTINGS_MODULE fragdenstaat_de.settings.development
 ENV DJANGO_CONFIGURATION Dev
 ENV NODE_ENV development
 
-RUN apt-get update -y && apt-get install -y build-essential binutils libproj-dev libpq-dev gdal-bin libgeos-dev libgeos-c1 python-gdal
+RUN apt-get update -y && apt-get install -y build-essential binutils libproj-dev libpq-dev gdal-bin libgeos-dev libgeos-c1v5 python-gdal
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - && apt-get update -y && apt-get install -y nodejs
 


### PR DESCRIPTION
When `docker-compose build` is executed the build failed with the following error message:

```
E: Package 'libgeos-c1' has no installation candidate
```

Replacing `libgeos-c1` with `libgeos-c1v5` solves the problem.