### PR TITLE
Fix z-index for blog navbar

### DIFF
--- a/frontend/styles/blog.scss
+++ b/frontend/styles/blog.scss
@@ -5,6 +5,7 @@
 .navbar-blog {
   background-color: $blue;
   backdrop-filter: blur(10px);
+  z-index: 1;
 }
 
 @include media-breakpoint-down(sm) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31850/64923752-655f4f00-d7dd-11e9-905a-4438aa5e8bd1.png)
Das navbar-Dropdown versteckt sich aktuell hinter den Bildern im Blog.