### PR TITLE
add RandomOrder cms plugin

### DIFF
--- a/fragdenstaat_de/fds_cms/templates/cms/plugins/random_order.html
+++ b/fragdenstaat_de/fds_cms/templates/cms/plugins/random_order.html
@@ -1,0 +1,5 @@
+{% load cms_tags %}
+
+{% for plugin in shuffled_children %}
+  {% render_plugin plugin %}
+{% endfor %}

--- a/fragdenstaat_de/theme/cms_plugins.py
+++ b/fragdenstaat_de/theme/cms_plugins.py
@@ -3,6 +3,8 @@ from django.utils.translation import gettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+import random
+
 
 COLUMNS = [
     (2, _('Two')),
@@ -52,7 +54,7 @@ CONTAINER_PLUGINS = [
     'DesignContainerPlugin'  # TODO: remove this one
 ]
 
-ROW_PARENTS = COLUMN_PLUGINS + CONTAINER_PLUGINS
+ROW_PARENTS = COLUMN_PLUGINS + CONTAINER_PLUGINS + ['RandomOrderPlugin']
 
 
 @plugin_pool.register_plugin
@@ -155,3 +157,24 @@ class PageSubMenuPlugin(CMSPluginBase):
     module = _("Menu")
     name = _("Page Sub Menu")
     render_template = "cms/plugins/page_submenu.html"
+
+
+@plugin_pool.register_plugin
+class RandomOrderPlugin(CMSPluginBase):
+    module = _("Elements")
+    name = _("Shuffle Plugins Randomly")
+    allow_children = True
+    render_template = "cms/plugins/random_order.html"
+
+    def render(self, context, instance, placeholder):
+        context = super().render(context, instance, placeholder)
+
+        children = instance.child_plugin_instances
+        if len(children) == 1 and children[0].plugin_type in ['Bootstrap4GridRowPlugin', 'RowPlugin']:
+            columns = children[0].child_plugin_instances
+            children[0].child_plugin_instances = random.sample(columns, len(columns))
+            context['shuffled_children'] = children
+        else:
+            context['shuffled_children'] = random.sample(children, len(children))
+
+        return context


### PR DESCRIPTION
This plugin renders all child instances in random order. If the only child is a Row/Bootstrap Row, its children will be shuffled.