### PR TITLE
🚸 swap default share image

### DIFF
--- a/fragdenstaat_de/fds_cms/templates/fds_cms/social_meta.html
+++ b/fragdenstaat_de/fds_cms/templates/fds_cms/social_meta.html
@@ -37,6 +37,7 @@
   <meta name="twitter:image:src" content="{% thumbnail object.fdspageextension.image 1120x600 crop subject_location=object.fdspageextension.image.subject_location %}">
 {% else %}
   <meta name="twitter:card" content="summary">
+  <meta name="twitter:image:src" content="{{ SITE_LOGO }}">
 {% endif %}
 
 
@@ -50,6 +51,8 @@
   <meta property="og:image" content="{{ image_url }}" />
 {% elif object.fdspageextension.image %}
   <meta property="og:image" content="{% thumbnail object.fdspageextension.image 1200x630 crop subject_location=object.fdspageextension.image.subject_location %}" />
+{% else %}
+  <meta property="og:image" content="{{ SITE_LOGO }}">
 {% endif %}
 {% if description and description != "None" %}
   <meta property="og:description" content="{{ description }}" />

--- a/fragdenstaat_de/settings/base.py
+++ b/fragdenstaat_de/settings/base.py
@@ -481,7 +481,7 @@ class FragDenStaatBase(German, Base):
     # ######### Debug ###########
 
     SITE_NAME = "FragDenStaat"
-    SITE_LOGO = "https://media.frag-den-staat.de/files/media/main/2a/72/2a720c74-7856-48fe-8eca-97a02f5a0504/logo_name_weiss.jpg"
+    SITE_LOGO = "https://media.frag-den-staat.de/files/media/main/f9/21/f9211ce7-9924-47da-913f-3070dbd4d298/og-default-sm.png"
     SITE_EMAIL = "info@fragdenstaat.de"
     SITE_URL = "http://localhost:8000"
 


### PR DESCRIPTION
New proposed default `og:image` with `summary`-style preview (small square image with title and description)

> <img src="https://media.frag-den-staat.de/files/media/main/f9/21/f9211ce7-9924-47da-913f-3070dbd4d298/og-default-sm.png" alt="FragDenStaat logo" width="128">