### PR TITLE
🐛 Fix nbsp in spans disappearing

### DIFF
--- a/fragdenstaat_de/templates/djangocms_frontend/bootstrap5/grid_row.html
+++ b/fragdenstaat_de/templates/djangocms_frontend/bootstrap5/grid_row.html
@@ -1,0 +1,8 @@
+{% load cms_tags %}
+    <{{ instance.tag_type }}{{ instance.get_attributes }}>
+    {% for plugin in instance.child_plugin_instances %}
+        {% if plugin.plugin_type == "CardPlugin" %}<div class="col mb-3">{% endif %}
+        {% with forloop as parentloop %}{% render_plugin plugin %}{% endwith %}
+        {% if plugin.plugin_type == "CardPlugin" %}</div>{% endif %}
+    {% endfor %}
+    </{{ instance.tag_type }}>

--- a/fragdenstaat_de/templates/djangocms_frontend/html_container.html
+++ b/fragdenstaat_de/templates/djangocms_frontend/html_container.html
@@ -1,0 +1,7 @@
+{% load cms_tags %}
+
+<{{ instance.tag_type }}{{ instance.get_attributes }}>
+{% for plugin in instance.child_plugin_instances %}
+    {% with parentloop=forloop parent=instance %}{% render_plugin plugin %}{% endwith %}
+{% empty %}{{ instance.simple_content }}{% endfor %}
+</{{ instance.tag_type }}>

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,53 @@
+from cms import api
+from cms.api import add_plugin
+from cms.test_utils.testcases import CMSTestCase
+from djangocms_text_ckeditor.cms_plugins import TextPlugin
+
+MARKER_BEFORE = "MAGIC_MARKER_BEFORE"
+MARKER_AFTER = "MAGIC_MARKER_AFTER"
+
+
+class MiscTests(CMSTestCase):
+    def test_text_plugin_nbsp_span(self):
+        """
+        Regression test: When a span contained only a nbsp, it's content was removed
+
+        We use such spans for formatting, e.g. a span with a user-select: none for spaces in IBANs
+        """
+        page = api.create_page("TestPage", "cms/home.html", "en")
+        ph = page.placeholders.get(slot="content")
+        grid_row = add_plugin(
+            ph,
+            "GridRowPlugin",
+            "en",
+            config={"vertical_alignment": "auto", "horizontal_alignment": "auto"},
+        )
+        grid_column = add_plugin(
+            ph,
+            "GridColumnPlugin",
+            "en",
+            config={"column_alignment": "auto"},
+            target=grid_row,
+        )
+        add_plugin(
+            ph,
+            TextPlugin,
+            "en",
+            body=f"{MARKER_BEFORE}<span>&nbsp;</span>{MARKER_AFTER}",
+            target=grid_column,
+        )
+
+        page.publish("en")
+
+        page_url = page.get_absolute_url()
+        staff_user = self.get_staff_user_with_no_permissions()
+
+        with self.login_user_context(staff_user):
+            response = self.client.get(page_url)
+
+        content = response.content.decode()
+        model_content_start = content.index(MARKER_BEFORE) + len(MARKER_BEFORE)
+        model_content_end = content.index(MARKER_AFTER)
+        model_content = content[model_content_start:model_content_end]
+
+        self.assertIn(model_content, ["<span>&nbsp;</span>", "<span>\xa0</span>"])


### PR DESCRIPTION
The templates are basically the same as the upstream ones, but without the `spaceless` tags:

https://github.com/django-cms/djangocms-frontend/blob/master/djangocms_frontend/templates/djangocms_frontend/html_container.html

https://github.com/django-cms/djangocms-frontend/blob/master/djangocms_frontend/contrib/grid/templates/djangocms_frontend/bootstrap5/grid_row.html