### PR TITLE
Add frame-ancestors CSP value to X-Frame-Options middleware

### DIFF
--- a/fragdenstaat_de/settings/base.py
+++ b/fragdenstaat_de/settings/base.py
@@ -465,7 +465,7 @@ class FragDenStaatBase(German, Base):
         FROIDE_CSRF_MIDDLEWARE,
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
-        "django.middleware.clickjacking.XFrameOptionsMiddleware",
+        "fragdenstaat_de.theme.middleware.XFrameOptionsCSPMiddleware",
         "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
         "fragdenstaat_de.theme.redirects.PathRedirectFallbackMiddleware",
         "froide.account.middleware.AcceptNewTermsMiddleware",

--- a/fragdenstaat_de/theme/middleware.py
+++ b/fragdenstaat_de/theme/middleware.py
@@ -1,0 +1,9 @@
+from django.middleware.clickjacking import XFrameOptionsMiddleware
+
+
+class XFrameOptionsCSPMiddleware(XFrameOptionsMiddleware):
+    def process_response(self, request, response):
+        response = super().process_response(request, response)
+        if response.has_header("X-Frame-Options"):
+            response.headers["Content-Security-Policy"] = "frame-ancestors 'self'"
+        return response


### PR DESCRIPTION
The standard `X-Frame-Options` middleware and the opt-out view decorator `xframe_options_exempt` are not aware of `frame-ancestor` value in our CSP.

Solution here: remove `frame-ancestor` from our standard nginx provided CSP and now set it by default in Django when the `X-Frame-Options` header is sent (ie when the response is not exempt).