### PR TITLE
organization updates

### DIFF
--- a/fragdenstaat_de/settings/base.py
+++ b/fragdenstaat_de/settings/base.py
@@ -443,7 +443,10 @@ class FragDenStaatBase(German, Base):
         "filer.thumbnail_processors.scale_and_crop_with_subject_location",
         "easy_thumbnails.processors.filters",
     )
-    THUMBNAIL_PRESERVE_EXTENSIONS = ("png",)
+    THUMBNAIL_PRESERVE_EXTENSIONS = (
+        "png",
+        "svg",
+    )
 
     META_SITE_PROTOCOL = "http"
     META_USE_SITES = True

--- a/fragdenstaat_de/templates/organization/includes/organization_item.html
+++ b/fragdenstaat_de/templates/organization/includes/organization_item.html
@@ -1,15 +1,12 @@
 {% load i18n easy_thumbnails_tags cms_tags %}
 
-<article id="organization-{{ object.slug }}"
-         class="organization-item md:shadow-gray border-gray p-4 mx-auto h-100">
-  <h4 class="blog-list-heading mb-4">
+<article id="organization-{{ object.slug }}" class="md:shadow-gray border-gray p-3 mx-auto h-100 d-flex flex-column">
+  <h4 class="mb-4">
     <a href="{{ object.get_absolute_url }}">
       {% if object.logo %}
- 
-        <img src="{% if object.logo.url.lower|slice:"-4:" == ".svg" %}{{ object.logo.url }}{% else %}{% thumbnail object.logo 300x0 %}{% endif %}"
-             class="h-1-5em mw-100"
-             alt="{{ object.name }}"/>
- 
+        <img src="{% thumbnail object.logo 300x0 %}"
+          class="partner-logo"
+          alt="{{ object.name }}"/>
       {% else %}
         {{ object.name }}
       {% endif %}
@@ -19,4 +16,10 @@
   {% if object.description %}
     <div class="organization-description">{{ object.description | truncatewords_html:TRUNCWORDS_COUNT | safe }}</div>
   {% endif %}
+
+  <div class="mt-auto pt-3">
+    <a href="{{ object.get_absolute_url }}">
+      → {% trans "View organization" %}
+    </a>
+  </div>
 </article>

--- a/fragdenstaat_de/templates/organization/organization_list.html
+++ b/fragdenstaat_de/templates/organization/organization_list.html
@@ -18,15 +18,13 @@
   </div>
   <div class="container">
     <h1 class="py-4">{% trans "Organizations" %}</h1>
-    <div class="row shuffle-items">
+    <div class="row shuffle-items gx-3 gy-3">
       {% for object in object_list %}
-        <div class="col-md-6 col-lg-4 mb-5">
+        <div class="col-md-6 col-lg-4">
           {% include "organization/includes/organization_item.html" with object=object TRUNCWORDS_COUNT=TRUNCWORDS_COUNT %}
         </div>
       {% empty %}
-        <div class="col-md-4">
-          <p>{% trans "No organizations found." %}</p>
-        </div>
+        <p>{% trans "No organizations found." %}</p>
       {% endfor %}
     </div>
   </div>

--- a/frontend/styles/cms_utils.scss
+++ b/frontend/styles/cms_utils.scss
@@ -172,16 +172,6 @@ $backdrops: (
   }
 }
 
-.partner-logos img,
-.partner-logo {
-  display: block;
-  width: 12rem;
-  max-width: 100%;
-  height: 6rem;
-  margin: 1rem auto;
-  object-fit: contain;
-}
-
 .reveal-cutoff {
   .reveal-inner {
     position: relative;

--- a/frontend/styles/cms_utils.scss
+++ b/frontend/styles/cms_utils.scss
@@ -138,40 +138,6 @@ $backdrops: (
   }
 }
 
-/* images */
-.hero-illustration,
-.img-lg,
-.img-sm {
-  width: 12rem;
-  max-width: 100%;
-  height: auto;
-  max-height: 12rem;
-  object-fit: contain;
-
-  @include media-breakpoint-up(lg) {
-    width: 16rem;
-    max-height: 16rem;
-  }
-}
-
-.img-sm {
-  width: 5rem;
-  max-height: 5rem;
-}
-
-.img-sm-vertical {
-  height: 5rem;
-  max-width: 100%;
-}
-
-@include media-breakpoint-down(sm) {
-  .hero-illustration-vertical {
-    width: auto;
-    max-width: 100%;
-    height: 12rem;
-  }
-}
-
 .reveal-cutoff {
   .reveal-inner {
     position: relative;


### PR DESCRIPTION
- 🔧 preserve `.svg` extension for thumbnails
- 💄 move `.partner-logo` class to froide
- 💄 move image classes to froide
- 💄 refine organization pages

:warning: requires okfde/froide#635
