### PR TITLE
Remove djangocms-bootstrap4

### DIFF
--- a/fragdenstaat_de/fds_cms/cms_plugins.py
+++ b/fragdenstaat_de/fds_cms/cms_plugins.py
@@ -5,7 +5,6 @@ from django.utils.translation import gettext_lazy as _
 
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
-from djangocms_bootstrap4.helpers import concat_classes
 
 from froide.foirequest.models import FoiRequest
 from froide.helper.utils import get_redirect_url
@@ -37,6 +36,7 @@ from .models import (
     SVGImageCMSPlugin,
     VegaChartCMSPlugin,
 )
+from .utils import concat_classes
 
 
 @plugin_pool.register_plugin

--- a/fragdenstaat_de/fds_cms/migrations/0029_auto_20200612_1243.py
+++ b/fragdenstaat_de/fds_cms/migrations/0029_auto_20200612_1243.py
@@ -3,7 +3,7 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-import djangocms_bootstrap4.fields
+import djangocms_frontend.fields
 
 
 class Migration(migrations.Migration):
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
                 ("identifier", models.CharField(max_length=255)),
                 (
                     "tag_type",
-                    djangocms_bootstrap4.fields.TagTypeField(
+                    djangocms_frontend.fields.TagTypeField(
                         choices=[
                             ("div", "div"),
                             ("section", "section"),
@@ -49,13 +49,13 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "attributes",
-                    djangocms_bootstrap4.fields.AttributesField(
+                    djangocms_frontend.fields.AttributesField(
                         blank=True, default=dict, verbose_name="Attributes"
                     ),
                 ),
                 (
                     "dialog_attributes",
-                    djangocms_bootstrap4.fields.AttributesField(
+                    djangocms_frontend.fields.AttributesField(
                         blank=True, default=dict, verbose_name="Attributes"
                     ),
                 ),

--- a/fragdenstaat_de/fds_cms/migrations/0036_extraclasses_to_attributes.py
+++ b/fragdenstaat_de/fds_cms/migrations/0036_extraclasses_to_attributes.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-import djangocms_bootstrap4.fields
+import djangocms_frontend.fields
 
 models = (
     "cardcmsplugin",
@@ -32,35 +32,35 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="cardcmsplugin",
             name="attributes",
-            field=djangocms_bootstrap4.fields.AttributesField(
+            field=djangocms_frontend.fields.AttributesField(
                 blank=True, default=dict, verbose_name="Attributes"
             ),
         ),
         migrations.AddField(
             model_name="cardheadercmsplugin",
             name="attributes",
-            field=djangocms_bootstrap4.fields.AttributesField(
+            field=djangocms_frontend.fields.AttributesField(
                 blank=True, default=dict, verbose_name="Attributes"
             ),
         ),
         migrations.AddField(
             model_name="cardiconcmsplugin",
             name="attributes",
-            field=djangocms_bootstrap4.fields.AttributesField(
+            field=djangocms_frontend.fields.AttributesField(
                 blank=True, default=dict, verbose_name="Attributes"
             ),
         ),
         migrations.AddField(
             model_name="cardimagecmsplugin",
             name="attributes",
-            field=djangocms_bootstrap4.fields.AttributesField(
+            field=djangocms_frontend.fields.AttributesField(
                 blank=True, default=dict, verbose_name="Attributes"
             ),
         ),
         migrations.AddField(
             model_name="cardinnercmsplugin",
             name="attributes",
-            field=djangocms_bootstrap4.fields.AttributesField(
+            field=djangocms_frontend.fields.AttributesField(
                 blank=True, default=dict, verbose_name="Attributes"
             ),
         ),

--- a/fragdenstaat_de/fds_cms/migrations/0038_cardlinkcmsplugin.py
+++ b/fragdenstaat_de/fds_cms/migrations/0038_cardlinkcmsplugin.py
@@ -4,7 +4,7 @@ import django.db.models.deletion
 from django.db import migrations, models
 
 import cms.models.fields
-import djangocms_bootstrap4.fields
+import djangocms_frontend.fields
 
 
 class Migration(migrations.Migration):
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "attributes",
-                    djangocms_bootstrap4.fields.AttributesField(
+                    djangocms_frontend.fields.AttributesField(
                         blank=True, default=dict, verbose_name="Attributes"
                     ),
                 ),

--- a/fragdenstaat_de/fds_cms/migrations/0046_revealmorecmsplugin.py
+++ b/fragdenstaat_de/fds_cms/migrations/0046_revealmorecmsplugin.py
@@ -3,7 +3,7 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-import djangocms_bootstrap4.fields
+import djangocms_frontend.fields
 
 
 class Migration(migrations.Migration):
@@ -101,7 +101,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "attributes",
-                    djangocms_bootstrap4.fields.AttributesField(
+                    djangocms_frontend.fields.AttributesField(
                         blank=True, default=dict, verbose_name="Attributes"
                     ),
                 ),

--- a/fragdenstaat_de/fds_cms/migrations/0049_borderedsectioncmsplugin.py
+++ b/fragdenstaat_de/fds_cms/migrations/0049_borderedsectioncmsplugin.py
@@ -3,7 +3,7 @@
 import django.db.models.deletion
 from django.db import migrations, models
 
-import djangocms_bootstrap4.fields
+import djangocms_frontend.fields
 
 
 class Migration(migrations.Migration):
@@ -70,7 +70,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "attributes",
-                    djangocms_bootstrap4.fields.AttributesField(
+                    djangocms_frontend.fields.AttributesField(
                         blank=True, default=dict, verbose_name="Attributes"
                     ),
                 ),

--- a/fragdenstaat_de/fds_cms/models.py
+++ b/fragdenstaat_de/fds_cms/models.py
@@ -7,7 +7,7 @@ from cms.extensions import PageExtension
 from cms.extensions.extension_pool import extension_pool
 from cms.models.fields import PageField
 from cms.models.pluginmodel import CMSPlugin
-from djangocms_bootstrap4.fields import AttributesField, TagTypeField
+from djangocms_frontend.fields import AttributesField, TagTypeField
 from filer.fields.file import FilerFileField
 from filer.fields.image import FilerImageField
 from filingcabinet.models import DocumentPortal, PageAnnotation

--- a/fragdenstaat_de/fds_cms/utils.py
+++ b/fragdenstaat_de/fds_cms/utils.py
@@ -48,3 +48,10 @@ def render_placeholder(context, placeholder, use_cache=False):
         placeholder, context=context, nodelist=None, editable=False, use_cache=use_cache
     )
     return content
+
+
+def concat_classes(classes):
+    """
+    merges a list of classes and return concatinated string
+    """
+    return " ".join(_class for _class in classes if _class)

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -223,7 +223,6 @@ django-cms==3.11.1
     #   -r requirements.in
     #   djangocms-attributes-field
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-icon
     #   djangocms-link
@@ -252,7 +251,6 @@ django-filer==2.2.3
     # via
     #   -r requirements.in
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-link
     #   djangocms-picture
@@ -338,7 +336,6 @@ djangocms-admin-style==3.2.1
 djangocms-attributes-field==2.1.0
     # via
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-icon
     #   djangocms-link
@@ -346,26 +343,20 @@ djangocms-attributes-field==2.1.0
     #   djangocms-video
 djangocms-audio==2.0.0
     # via -r requirements.in
-djangocms-bootstrap4==3.0.0
-    # via -r requirements.in
 djangocms-frontend==1.0.1
     # via -r requirements.in
 djangocms-icon==2.0.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-link==3.1.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-picture==4.0.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-text-ckeditor==5.1.1
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
     #   djangocms-frontend
 djangocms-video==3.0.0
     # via -r requirements.in

--- a/requirements.in
+++ b/requirements.in
@@ -30,8 +30,6 @@ Django>=4.1,<4.2
 djangocms-audio
 djangocms-frontend>=1.0.1
 djangocms-link>=3.1.0
-# Remove when no longer imported
-djangocms-bootstrap4>=3
 djangocms-icon
 djangocms-picture
 djangocms-text-ckeditor>=5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -213,7 +213,6 @@ django-cms==3.11.1
     #   -r requirements.in
     #   djangocms-attributes-field
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-icon
     #   djangocms-link
@@ -242,7 +241,6 @@ django-filer==2.2.3
     # via
     #   -r requirements.in
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-link
     #   djangocms-picture
@@ -328,7 +326,6 @@ djangocms-admin-style==3.2.1
 djangocms-attributes-field==2.1.0
     # via
     #   djangocms-audio
-    #   djangocms-bootstrap4
     #   djangocms-frontend
     #   djangocms-icon
     #   djangocms-link
@@ -336,26 +333,20 @@ djangocms-attributes-field==2.1.0
     #   djangocms-video
 djangocms-audio==2.0.0
     # via -r requirements.in
-djangocms-bootstrap4==3.0.0
-    # via -r requirements.in
 djangocms-frontend==1.0.1
     # via -r requirements.in
 djangocms-icon==2.0.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-link==3.1.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-picture==4.0.0
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
 djangocms-text-ckeditor==5.1.1
     # via
     #   -r requirements.in
-    #   djangocms-bootstrap4
     #   djangocms-frontend
 djangocms-video==3.0.0
     # via -r requirements.in


### PR DESCRIPTION
We use djangocms-frontend now, all mentions have been replaced or removed.