### PR TITLE
🩹 fix svg images in djangocms-picture and cards

### DIFF
--- a/fragdenstaat_de/fds_cms/templates/fds_cms/card/card_image.html
+++ b/fragdenstaat_de/fds_cms/templates/fds_cms/card/card_image.html
@@ -4,8 +4,9 @@
 {% if instance.link %}<a href="{{ instance.link }}"{% else %}<div{% endif %} class="d-block box-card-image overlap-{{ instance.overlap }}{% if instance.overlap == 'left' %} col-md-4 col-lg-3{% endif %} text-center">
   {% with picture=instance.image %}
     <picture>
-      {% if ".svg" not in picture.url %}
         {% thumbnail picture size.0 crop=smart subject_location=picture.subject_location as thumb %}
+        
+        {% if picture.mime_type != "image/svg+xml" %}
         <source
           media="(min-width: 992px)"
           srcset="{{ thumb.url }}.avif"
@@ -20,8 +21,9 @@
           srcset="{{ thumb.url }}.avif"
           type="image/avif"
         />
-      {% endif %}
-      <img class="img-{{ instance.size }} z-index-10 {{ instance.attributes.class }}" loading="lazy" width="{{ thumb.width }}" height="{{ thumb.height }}" src="{{ thumb.url }}"
+        {% endif %}
+        
+      <img class="img-{{ instance.size }} z-index-10 {{ instance.attributes.class }}" loading="lazy" width="{{ thumb.width|floatformat:"0u" }}" height="{{ thumb.height|floatformat:"0u" }}" src="{{ thumb.url }}"
           {% if not attributes.alt %} alt="{{ picture.default_alt_text|default:"" }}"{% endif %}
           {{ instance.attributes_str }}>
     </picture>

--- a/fragdenstaat_de/templates/djangocms_picture/default/picture.html
+++ b/fragdenstaat_de/templates/djangocms_picture/default/picture.html
@@ -16,7 +16,7 @@
 
 {% if not instance.external_picture and not instance.use_no_cropping %}
 <picture>
-  {% if not instance.width and not instance.height %}
+  {% if not instance.width and not instance.height and instance.picture.mime_type != "image/svg+xml" %}
     {% thumbnail instance.picture 1140x0 subject_location=instance.picture.subject_location as thumb %}
     {% if thumb.url %}
       <source
@@ -43,14 +43,14 @@
     {% endif %}
   {% endif %}
 
-  {% if instance.external_picture or instance.use_no_cropping%}
+  {% if instance.external_picture or instance.use_no_cropping %}
     {# Empty #}
   {% elif instance.width or instance.height %}
     {% thumbnail instance.picture instance|thumbnail_dims crop=scale subject_location=instance.picture.subject_location as thumb %}
   {% else %}
     {% thumbnail instance.picture 768x0 crop=scale subject_location=instance.picture.subject_location as thumb %}
   {% endif %}
-  {% if thumb.url %}
+  {% if thumb.url and instance.picture.mime_type != "image/svg+xml" %}
     <source
       srcset="{{ thumb.url }}.avif"
       type="image/avif"


### PR DESCRIPTION
svg in djangocms_picture currently only works when `Use original image` is enabled
