### PR TITLE
image improvements

### DIFF
--- a/fragdenstaat_de/fds_cms/cms_plugins.py
+++ b/fragdenstaat_de/fds_cms/cms_plugins.py
@@ -589,11 +589,7 @@ class FdsCardHeaderPlugin(CMSPluginBase):
         return super().render(context, instance, placeholder)
 
 
-THUMBNAIL_SIZES = {
-    "sm": ("100x0", "100x0"),
-    "lg": ("280x0", "200x0"),
-    "lg-wide": ("400x0", "400x0"),
-}
+THUMBNAIL_SIZES = {"sm": "100x0", "lg": "280x0", "lg-wide": "0x100"}
 
 
 @plugin_pool.register_plugin

--- a/fragdenstaat_de/fds_cms/templates/fds_cms/card/card_image.html
+++ b/fragdenstaat_de/fds_cms/templates/fds_cms/card/card_image.html
@@ -4,25 +4,19 @@
 {% if instance.link %}<a href="{{ instance.link }}"{% else %}<div{% endif %} class="d-block box-card-image overlap-{{ instance.overlap }}{% if instance.overlap == 'left' %} col-md-4 col-lg-3{% endif %} text-center">
   {% with picture=instance.image %}
     <picture>
-        {% thumbnail picture size.0 crop=smart subject_location=picture.subject_location as thumb %}
+        {% thumbnail picture size crop=smart subject_location=picture.subject_location as thumb %}
         
         {% if picture.mime_type != "image/svg+xml" %}
         <source
-          media="(min-width: 992px)"
           srcset="{{ thumb.url }}.avif"
           type="image/avif"
         />
         <source
-          media="(min-width: 992px)"
           srcset="{{ thumb.url }}"
-        />
-        {% thumbnail picture size.1 crop=smart subject_location=picture.subject_location as thumb %}
-        <source
-          srcset="{{ thumb.url }}.avif"
-          type="image/avif"
+          type="{{ picture.mime_type }}"
         />
         {% endif %}
-        
+
       <img class="img-{{ instance.size }} z-index-10 {{ instance.attributes.class }}" loading="lazy" width="{{ thumb.width|floatformat:"0u" }}" height="{{ thumb.height|floatformat:"0u" }}" src="{{ thumb.url }}"
           {% if not attributes.alt %} alt="{{ picture.default_alt_text|default:"" }}"{% endif %}
           {{ instance.attributes_str }}>

--- a/fragdenstaat_de/templates/djangocms_picture/default/picture.html
+++ b/fragdenstaat_de/templates/djangocms_picture/default/picture.html
@@ -27,6 +27,7 @@
       <source
         media="(min-width: 1200px)"
         srcset="{{ thumb.url }}"
+        type="{{ instance.picture.mime_type }}"
       />
     {% endif %}
     {% thumbnail instance.picture 940x0 subject_location=instance.picture.subject_location as thumb %}
@@ -39,6 +40,7 @@
       <source
         media="(min-width: 992px)"
         srcset="{{ thumb.url }}"
+        type="{{ instance.picture.mime_type }}"
       />
     {% endif %}
   {% endif %}

--- a/frontend/styles/cards.scss
+++ b/frontend/styles/cards.scss
@@ -79,9 +79,12 @@ a > .box-card {
       &.img-lg-wide {
         max-width: 100%;
         width: auto;
-        max-height: 5rem;
-        height: auto;
+        height: 5rem;
         margin-top: -2.5rem;
+        object-fit: contain;
+        object-position: center;
+        padding: 0 1rem;
+        background-color: var(--bs-body-bg);
       }
     }
   }


### PR DESCRIPTION
- 🩹 add mime type to non-avif source tag too
- ♻️ drop mobile card images, negligible difference
- 💄 adjust wide card images (no more manual image padding)
