### PR TITLE
💄 Fix glider background color variable name

### DIFF
--- a/frontend/styles/glider.scss
+++ b/frontend/styles/glider.scss
@@ -91,7 +91,7 @@ $glide-modifier-separator: '--' !default;
     color: white;
     text-transform: uppercase;
     padding: 0.6rem;
-    background-color: var(--#{$prefix}bg-body);
+    background-color: var(--#{$prefix}-body-bg);
     // border: 1px solid transparent;
     border: none;
     border-radius: 50%;


### PR DESCRIPTION
There is no variable name `--bs-bg-body`, according to the docs it's `--bg-body-bg` https://getbootstrap.com/docs/5.3/customize/css-variables/#default