### PR TITLE
🩹 Fix devsetup for nix setup

### DIFF
--- a/dev.nix
+++ b/dev.nix
@@ -25,14 +25,14 @@ pkgs.mkShell {
   name = "fds";
   shellHook = ''
     echo "Launching fds shell"
-    export LD_LIBRARY_PATH=${builtins.concatStringsSep ":" (map (x: x + "/lib") ld_packages)}:$LD_LIBRARY_PATH
-    export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DYLD_LIBRARY_PATH
+    export FRAGDENSTAAT_DYLD_LIBRARY_PATH=${builtins.concatStringsSep ":" (map (x: x + "/lib") ld_packages)}
+    export LD_LIBRARY_PATH=$FRAGDENSTAAT_DYLD_LIBRARY_PATH:$LD_LIBRARY_PATH
+    export DYLD_LIBRARY_PATH=$FRAGDENSTAAT_DYLD_LIBRARY_PATH:$DYLD_LIBRARY_PATH
+
     source fds-env/bin/activate
-    source dslr-complete.bash
-    echo ${libcxx.dev}
+
     export CPATH="$CPATH:${mupdf.dev}/include/mupdf"
     export PYTHONBREAKPOINT=ipdb.set_trace
-    # export DATABASE_URL=postgis://fragdenstaat_de:fragdenstaat_de@localhost:5432/fragdenstaat_de
     export GDAL_LIBRARY_PATH=${gdal}/lib/libgdal.dylib
     export GEOS_LIBRARY_PATH=${geos}/lib/libgeos_c.dylib
     
@@ -40,6 +40,8 @@ pkgs.mkShell {
     
     export CFLAGS="-stdlib=libc++ -DUSE_STD_NAMESPACE -I${libcxx.dev}/include/c++/v1"
     export MACOSX_DEPLOYMENT_TARGET=10.9
+
+    export MAGICK_HOME="${imagemagick}"
   '';
   buildInputs = [
     pythonPackages.python
@@ -50,15 +52,14 @@ pkgs.mkShell {
     pythonPackages.magic
     pythonPackages.ocrmypdf
     pythonPackages.weasyprint
-    #pythonPackages.tensorflow
-    
+
     pkgconfig
     geos
     cairo
     pango
     gettext
     harfbuzz_self
-    imagemagick  
+    imagemagick
     poppler_utils
     libspatialite
     file
@@ -69,13 +70,9 @@ pkgs.mkShell {
     postgresql14Packages.postgis
     gdal
     mupdf
-    
+
     glib
     libcxx
     cmake
-
-    # magic-wormhole
-    # ansible
-    # boost.dev
-  ];
+  ] ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreText);
 }

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -ex
 
+# macOS's System Integrity Protection purges the environment variables controlling
+# `dyld` when launching protected processes (https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/RuntimeProtections/RuntimeProtections.html#//apple_ref/doc/uid/TP40016462-CH3-SW1)
+# This causes macOS to remove the DYLD_ env variables when running this script, so we have to set them again
+if [ !  -z "${FRAGDENSTAAT_DYLD_LIBRARY_PATH:-}" ]; then
+    export LD_LIBRARY_PATH=${FRAGDENSTAAT_DYLD_LIBRARY_PATH:-}:${LD_LIBRARY_PATH:-}
+    export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:${DYLD_LIBRARY_PATH:-}
+fi
+
 MAIN=fragdenstaat_de
 REPOS=("froide" "froide-campaign" "froide-legalaction" "froide-food" "froide-payment" "froide-crowdfunding" "froide-govplan" "froide-fax" "froide-exam" "django-filingcabinet")
 FRONTEND_DIR=("froide" "froide_food" "froide_exam" "froide_campaign" "froide_payment" "froide_legalaction" "filingcabinet")


### PR DESCRIPTION
This is a bit of an ugly hack: the devsetup calls some django management
commands that need native libraries (in this case: weasyprint needing
gobject). We set them through DYLD_LIBRARY_PATH, but macOS strips that
when calling devsetup.sh, so we have to set it again inside the devsetup
script.

I'm sure there is a better way to do that, we probably shouldn't be
setting (DY)LD_LIBRARY_PATH in the first place. But I couldn't figure it
out yet.
