### PR TITLE
🩹 fix data resolution for charts with datasets

### DIFF
--- a/frontend/javascript/vegacharts.js
+++ b/frontend/javascript/vegacharts.js
@@ -65,7 +65,7 @@ document.querySelectorAll('[data-vegachart]').forEach((el) => {
   } else {
     spec = JSON.parse(document.getElementById(el.dataset.vegachart).textContent)
   }
-  if (!spec.data.url && !spec.data.values) {
+  if (!spec.data.url && !spec.data.values && !spec.datasets) {
     const data = JSON.parse(
       document.getElementById(el.dataset.vegachart + '_data').textContent
     )


### PR DESCRIPTION
By default, Altair exports to Vega like this:

```json
  "data": {
    "name": "data-716699051e44dcc44a893338489d4f65"
  },
  "datasets": {
    "data-716699051e44dcc44a893338489d4f65": [
```

Currently our implementation fails on resolving the data, as it tries to lookup some element with an id that does not exist (as there is no `url` or `data.values`, which is not required though).