### PR TITLE
Make vega charts dark mode compatible

### DIFF
--- a/frontend/javascript/vegacharts.js
+++ b/frontend/javascript/vegacharts.js
@@ -1,7 +1,47 @@
 import '../styles/vega.scss'
 
 import { expressionInterpreter } from 'vega-interpreter'
+import { mergeConfig } from 'vega'
 import embed from 'vega-embed'
+
+const backgroundColor = 'var(--bs-body-bg)'
+const textColor = 'var(--bs-body-color)'
+const mediumColor = 'var(--bs-secondary-bg)'
+
+const colorTheme = {
+  background: backgroundColor,
+
+  view: {
+    stroke: mediumColor
+  },
+
+  title: {
+    color: textColor,
+    subtitleColor: textColor
+  },
+
+  style: {
+    'guide-label': {
+      fill: textColor
+    },
+    'guide-title': {
+      fill: textColor
+    },
+    cell: { stroke: null },
+    'group-title': { font: 'Inter', fontSize: 14, fontWeight: 'bold' }
+  },
+
+  axis: {
+    domainColor: mediumColor,
+    gridColor: mediumColor,
+    tickColor: mediumColor,
+    labelColor: textColor,
+    labelFont: 'Inter',
+    labelFontSize: 12,
+    titleFont: 'Inter',
+    titleFontWeight: 'normal'
+  }
+}
 
 const LOCALE = {
   de: {
@@ -95,6 +135,7 @@ document.querySelectorAll('[data-vegachart]').forEach((el) => {
     expr: expressionInterpreter,
     renderer: 'svg',
     actions: showActions,
+    config: mergeConfig(colorTheme, spec.config),
     ...extras
   })
 })

--- a/frontend/styles/vega.scss
+++ b/frontend/styles/vega.scss
@@ -1,3 +1,6 @@
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+
 .vega-chart {
   overflow: hidden;
   width: 100%;
@@ -8,4 +11,14 @@
 }
 .vega-embed {
   width: 100%;
+}
+
+#vg-tooltip-element {
+  background-color: var(--#{$prefix}body-bg);
+  border: 1px solid var(--#{$prefix}tertiary-bg);
+  color: var(--#{$prefix}body-color);
+
+  td.key {
+    color: var(--#{$prefix}secondary-color);
+  }
 }


### PR DESCRIPTION
This means style information needs to be removed from spec config key in plugins via e.g.

```python
import json
from fragdenstaat_de.fds_cms.cms_plugins import VegaChartCMSPlugin

charts = VegaChartCMSPlugin.objects.all()
for chart in charts:
    vega = json.loads(chart.vega_json)
    changed = vega.pop("background", None)
    config = vega.get("config")
    if config and config.get("axis", {}).get("domainColor"):
        vega.pop("config")
        changed = True
    if changed:
        print(chart.title)
        print(vega.get("background"), vega.get("config"))
        chart.vega_json = json.dumps(vega)
        chart.save()
```

Ideally, the chart specs do not come with colour values. This PR makes it so that the spec colours takes precedence over the theme colors, in case you want to adjust per chart.