### PR TITLE
💄 remove inline progress-bar height

### DIFF
--- a/fragdenstaat_de/fds_donation/templates/fds_donation/cms_plugins/donation_progress_bar.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/cms_plugins/donation_progress_bar.html
@@ -3,8 +3,7 @@
 {% with amount_str=amount|intcomma donation_goal_str=donation_goal|intcomma reached_goal_str=reached_goal|intcomma %}
     <div>
         <div class="progress"
-             style="height: 25px;
-                    {% if amount > donation_goal %}background-color: #ffa5a5{% endif %}">
+             style="{% if amount > donation_goal %}background-color: #ffa5a5{% endif %}">
             {% if reached_goal %}
                 <div class="progress-bar progress-bar-striped"
                      role="progressbar"


### PR DESCRIPTION
Bootstrap sets it to `1rem` per default, which seems appropriate
