### PR TITLE
Render sitemap

### DIFF
--- a/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
+++ b/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-12 09:08-0500\n"
+"POT-Creation-Date: 2023-12-15 04:20-0600\n"
 "PO-Revision-Date: 2023-10-12 16:09+0200\n"
 "Last-Translator: Karl Engelhardt <karl.engelhardt@okfn.de>\n"
 "Language-Team: German <https://weblate.frag-den-staat.de/projects/froide/"
@@ -772,7 +772,6 @@ msgstr "Organisationen"
 msgid "No organizations found."
 msgstr "Keine Organisation gefunden."
 
-#. Translators: meta keywords
 #: fragdenstaat_de/templates/snippets/meta.html
 msgid ""
 "Freedom of Information Requests, Freedom of Information Law, Public Body "
@@ -782,8 +781,7 @@ msgstr ""
 "Behördeninformationen"
 
 #~ msgid "You like our work? Support us with a donation!"
-#~ msgstr ""
-#~ "Ihnen gefällt unsere Arbeit? Unterstützen Sie uns mit einer Spende!"
+#~ msgstr "Ihnen gefällt unsere Arbeit? Unterstützen Sie uns mit einer Spende!"
 
 #~ msgid "Donate now"
 #~ msgstr "Jetzt spenden"

--- a/fragdenstaat_de/theme/management/commands/render_sitemap.py
+++ b/fragdenstaat_de/theme/management/commands/render_sitemap.py
@@ -9,17 +9,33 @@ class Command(BaseCommand):
     help = "Render sitemap"
 
     def add_arguments(self, parser):
-        parser.add_argument("section", help="Render section", default="")
+        parser.add_argument(
+            "--section", help="Render section", default="", required=False
+        )
+        parser.add_argument(
+            "--getsections",
+            help="List available sections",
+            required=False,
+            action="store_true",
+        )
 
     def handle(self, *args, **options):
-        section = options["section"]
-        factory = RequestFactory()
-        if section:
-            request = factory.get("/sitemap-{}.xml".format(section))
-            response = sitemaps_views.sitemap(request, sitemaps)
+        if options["getsections"]:
+            for section in sitemaps:
+                self.stdout.write(section)
         else:
-            request = factory.get("/sitemap.xml")
-            response = sitemaps_views.index(
-                request, sitemaps, sitemap_url_name="sitemaps"
-            )
-        self.stdout.write(response.rendered_content)
+            section = options["section"]
+            factory = RequestFactory()
+            if section:
+                sitemap_name = "/sitemap-{}.xml".format(section)
+                request = factory.get(sitemap_name)
+                response = sitemaps_views.sitemap(request, sitemaps)
+            else:
+                sitemap_name = "/sitemap.xml"
+                request = factory.get(sitemap_name)
+                response = sitemaps_views.index(
+                    request, sitemaps, sitemap_url_name="sitemaps"
+                )
+            sitemap_dest_tmp = "/tmp/{}".format(sitemap_name)
+            with open(sitemap_dest_tmp, "w") as sitemap_out:
+                sitemap_out.write(response.rendered_content)

--- a/fragdenstaat_de/theme/management/commands/render_sitemap.py
+++ b/fragdenstaat_de/theme/management/commands/render_sitemap.py
@@ -1,3 +1,5 @@
+import os
+
 from django.contrib.sitemaps import views as sitemaps_views
 from django.core.management.base import BaseCommand
 from django.test import RequestFactory
@@ -18,24 +20,68 @@ class Command(BaseCommand):
             required=False,
             action="store_true",
         )
+        parser.add_argument(
+            "--outdir", help="Output directory", required=False, default="/tmp/"
+        )
+
+    def get_sections(self):
+        sections = []
+        for section in sitemaps:
+            sections.append(section)
+        return sections
+
+    def write_sitemap_tempfile(self, sitemap_file, sitemap_content):
+        with open(sitemap_file, "w") as sitemap_out:
+            sitemap_out.write(sitemap_content)
+        return True
 
     def handle(self, *args, **options):
+        sections = []
+        sections = self.get_sections()
+        section = options["section"]
+        outdir = options["outdir"]
+
         if options["getsections"]:
-            for section in sitemaps:
-                self.stdout.write(section)
-        else:
-            section = options["section"]
-            factory = RequestFactory()
-            if section:
-                sitemap_name = "/sitemap-{}.xml".format(section)
-                request = factory.get(sitemap_name)
-                response = sitemaps_views.sitemap(request, sitemaps)
-            else:
-                sitemap_name = "/sitemap.xml"
-                request = factory.get(sitemap_name)
-                response = sitemaps_views.index(
-                    request, sitemaps, sitemap_url_name="sitemaps"
+            for s in sections:
+                self.stdout.write(s)
+            exit()
+
+        if section and section not in sections:
+            self.stderr.write(
+                "Error: Section {} does not exists. Use '--getsections' for a valid list.".format(
+                    section
                 )
-            sitemap_dest_tmp = "/tmp/{}".format(sitemap_name)
-            with open(sitemap_dest_tmp, "w") as sitemap_out:
-                sitemap_out.write(response.rendered_content)
+            )
+            exit()
+
+        if not os.path.isdir(outdir):
+            self.stderr.write(
+                "Error: The directory {} does not exists, please check/create and try again.".format(
+                    outdir
+                )
+            )
+            exit()
+
+        self.stdout.write("Generating sitemap(s), this might take a while...")
+
+        if section:
+            sections.clear()
+            sections = [section]
+
+        for s in sections:
+            self.stdout.write("{}".format(s))
+            factory = RequestFactory()
+            sitemap_name = "/sitemap-{}.xml".format(s)
+            request = factory.get(sitemap_name)
+            response = sitemaps_views.sitemap(request, sitemaps, section=s)
+
+            sitemap_dest_tmp = "{}/{}".format(outdir, sitemap_name)
+            self.write_sitemap_tempfile(sitemap_dest_tmp, response.rendered_content)
+
+        sitemap_name = "/sitemap.xml"
+        request = factory.get(sitemap_name)
+        response = sitemaps_views.index(request, sitemaps, sitemap_url_name="sitemaps")
+        sitemap_dest_tmp = "{}/{}".format(outdir, sitemap_name)
+        self.write_sitemap_tempfile(sitemap_dest_tmp, response.rendered_content)
+
+        self.stdout.write("Done")

--- a/fragdenstaat_de/theme/management/commands/render_sitemap.py
+++ b/fragdenstaat_de/theme/management/commands/render_sitemap.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from django.contrib.sitemaps import views as sitemaps_views
 from django.core.management.base import BaseCommand
@@ -11,77 +11,78 @@ class Command(BaseCommand):
     help = "Render sitemap"
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--section", help="Render section", default="", required=False
-        )
-        parser.add_argument(
-            "--getsections",
+        subparsers = parser.add_subparsers(dest="subcommand", required=True)
+        getsections_parser = subparsers.add_parser(
+            "getsections",
             help="List available sections",
-            required=False,
-            action="store_true",
         )
-        parser.add_argument(
-            "--outdir", help="Output directory", required=False, default="/tmp/"
+        getsections_parser.set_defaults(func=self.getsections)
+
+        generate_parser = subparsers.add_parser("generate")
+        generate_parser.add_argument(
+            "--section",
+            help="Render section (can be specified multiple times)",
+            action="append",
+            default=[],
         )
+        generate_parser.add_argument(
+            "--outdir", help="Output directory", type=Path, default=Path("/tmp/")
+        )
+        generate_parser.set_defaults(func=self.generate)
 
     def get_sections(self):
-        sections = []
-        for section in sitemaps:
-            sections.append(section)
-        return sections
+        return sitemaps.keys()
 
     def write_sitemap_tempfile(self, sitemap_file, sitemap_content):
         with open(sitemap_file, "w") as sitemap_out:
             sitemap_out.write(sitemap_content)
         return True
 
-    def handle(self, *args, **options):
-        sections = []
+    def handle(self, *args, func, **kwargs):
+        func(**kwargs)
+
+    def getsections(self, **kwargs):
         sections = self.get_sections()
-        section = options["section"]
-        outdir = options["outdir"]
 
-        if options["getsections"]:
-            for s in sections:
-                self.stdout.write(s)
-            exit()
+        for s in sections:
+            self.stdout.write(s)
 
-        if section and section not in sections:
-            self.stderr.write(
-                "Error: Section {} does not exists. Use '--getsections' for a valid list.".format(
-                    section
+    def generate(self, section, outdir, **kwargs):
+        sections = self.get_sections()
+
+        unknown_sections = set(section) - set(sections)
+        if unknown_sections:
+            for unknown_section in unknown_sections:
+                self.stderr.write(
+                    f"Error: Section {unknown_section} does not exists. Use 'getsections' for a valid list."
                 )
-            )
-            exit()
+            return
 
-        if not os.path.isdir(outdir):
+        if not outdir.exists():
             self.stderr.write(
-                "Error: The directory {} does not exists, please check/create and try again.".format(
-                    outdir
-                )
+                f"Error: The directory {outdir} does not exists, please check/create and try again."
             )
-            exit()
+            return
 
         self.stdout.write("Generating sitemap(s), this might take a while...")
 
         if section:
-            sections.clear()
-            sections = [section]
+            sections = section
 
         for s in sections:
-            self.stdout.write("{}".format(s))
+            self.stdout.write(s)
             factory = RequestFactory()
-            sitemap_name = "/sitemap-{}.xml".format(s)
-            request = factory.get(sitemap_name)
+            sitemap_name = f"sitemap-{s}.xml"
+            request = factory.get("/" + sitemap_name)
             response = sitemaps_views.sitemap(request, sitemaps, section=s)
 
-            sitemap_dest_tmp = "{}/{}".format(outdir, sitemap_name)
+            sitemap_dest_tmp = outdir / sitemap_name
             self.write_sitemap_tempfile(sitemap_dest_tmp, response.rendered_content)
 
-        sitemap_name = "/sitemap.xml"
-        request = factory.get(sitemap_name)
+        sitemap_name = "sitemap.xml"
+        request = factory.get("/" + sitemap_name)
         response = sitemaps_views.index(request, sitemaps, sitemap_url_name="sitemaps")
-        sitemap_dest_tmp = "{}/{}".format(outdir, sitemap_name)
+        sitemap_dest_tmp = outdir / sitemap_name
         self.write_sitemap_tempfile(sitemap_dest_tmp, response.rendered_content)
 
         self.stdout.write("Done")

--- a/fragdenstaat_de/theme/management/commands/render_sitemap.py
+++ b/fragdenstaat_de/theme/management/commands/render_sitemap.py
@@ -1,0 +1,25 @@
+from django.contrib.sitemaps import views as sitemaps_views
+from django.core.management.base import BaseCommand
+from django.test import RequestFactory
+
+from fragdenstaat_de.theme.urls import sitemaps
+
+
+class Command(BaseCommand):
+    help = "Render sitemap"
+
+    def add_arguments(self, parser):
+        parser.add_argument("section", help="Render section", default="")
+
+    def handle(self, *args, **options):
+        section = options["section"]
+        factory = RequestFactory()
+        if section:
+            request = factory.get("/sitemap-{}.xml".format(section))
+            response = sitemaps_views.sitemap(request, sitemaps)
+        else:
+            request = factory.get("/sitemap.xml")
+            response = sitemaps_views.index(
+                request, sitemaps, sitemap_url_name="sitemaps"
+            )
+        self.stdout.write(response.rendered_content)


### PR DESCRIPTION
The sitemap generation takes too much time, so we want to generate them via cronjob and deliver "static" files. (I did not use pythons `tempfile` on purpose as I want to move the sitemap from tmp-Location to the proper location via cron, as currently only Ansible knows about `simple_files` definition.)