### PR TITLE
Added scheme for elasticsearch URLs in settings

### DIFF
--- a/fragdenstaat_de/fds_donation/locale/de/LC_MESSAGES/django.po
+++ b/fragdenstaat_de/fds_donation/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-03 06:53-0600\n"
+"POT-Creation-Date: 2024-01-29 06:01-0600\n"
 "PO-Revision-Date: 2022-09-29 13:54+0200\n"
 "Last-Translator: Stefan Wehrmeyer <stefan.wehrmeyer@okfn.de>\n"
 "Language-Team: \n"
@@ -238,6 +238,10 @@ msgstr "Sende {count} Opt-In-E-Mails."
 
 #: fragdenstaat_de/fds_donation/admin.py
 msgid "notify shipped and set date"
+msgstr ""
+
+#: fragdenstaat_de/fds_donation/admin.py
+msgid "export as csv"
 msgstr ""
 
 #: fragdenstaat_de/fds_donation/apps.py

--- a/fragdenstaat_de/settings/base.py
+++ b/fragdenstaat_de/settings/base.py
@@ -519,7 +519,7 @@ class FragDenStaatBase(German, Base):
 
     ELASTICSEARCH_INDEX_PREFIX = "fragdenstaat_de"
     ELASTICSEARCH_DSL = {
-        "default": {"hosts": "localhost:9200"},
+        "default": {"hosts": "http://localhost:9200"},
     }
     ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = "froide.helper.search.CelerySignalProcessor"
 

--- a/fragdenstaat_de/settings/production.py
+++ b/fragdenstaat_de/settings/production.py
@@ -204,7 +204,9 @@ class FragDenStaat(FragDenStaatBase):
     ELASTICSEARCH_INDEX_PREFIX = "fragdenstaat_de"
     ELASTICSEARCH_DSL = {
         "default": {
-            "hosts": env("DJANGO_ELASTICSEARCH_HOSTS", "localhost:9200").split(",")
+            "hosts": env("DJANGO_ELASTICSEARCH_HOSTS", "http://localhost:9200").split(
+                ","
+            )
         },
     }
     ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = "froide.helper.search.CelerySignalProcessor"

--- a/fragdenstaat_de/settings/test.py
+++ b/fragdenstaat_de/settings/test.py
@@ -34,6 +34,6 @@ class Test(FragDenStaatBase):
     )
     ELASTICSEARCH_INDEX_PREFIX = "fds_test"
     ELASTICSEARCH_DSL = {
-        "default": {"hosts": "localhost:9200"},
+        "default": {"hosts": "http://localhost:9200"},
     }
     FIXTURE_DIRS = [os.path.join(THEME_ROOT, "..", "tests", "fixtures")]


### PR DESCRIPTION
Elasticsearch requires a scheme otherwise commands like `manage.py search_index --create` will fail with: `ValueError: URL must include a 'scheme', 'host', and 'port' component (ie 'https://localhost:9200')`
