### PR TITLE
🐛 Run avif generation after thumbnail optimization

### DIFF
--- a/fragdenstaat_de/fds_cms/apps.py
+++ b/fragdenstaat_de/fds_cms/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-from django.conf import settings
 
 from easy_thumbnails.optimize import thumbnail_created_callback
 from easy_thumbnails.signals import thumbnail_created
@@ -19,23 +18,11 @@ class FdsCmsConfig(AppConfig):
         thumbnail_created.disconnect(thumbnail_created_callback)
         thumbnail_created.connect(async_optimize_thumbnail)
 
-        if settings.FDS_THUMBNAIL_ENABLE_AVIF:
-            thumbnail_created.connect(store_as_avif)
-
 
 def merge_user(sender, old_user=None, new_user=None, **kwargs):
     from .models import FoiRequestListCMSPlugin
 
     FoiRequestListCMSPlugin.objects.filter(user=old_user).update(user=new_user)
-
-
-def store_as_avif(sender, **kwargs):
-    if not sender.name.endswith((".png", ".jpg", ".jpeg")):
-        return
-
-    from .tasks import generate_avif_thumbnail
-
-    generate_avif_thumbnail.delay(sender.name, sender.storage)
 
 
 def async_optimize_thumbnail(sender, **kwargs):

--- a/fragdenstaat_de/fds_cms/tasks.py
+++ b/fragdenstaat_de/fds_cms/tasks.py
@@ -1,6 +1,7 @@
 import logging
 from io import BytesIO
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 
 from celery import shared_task
@@ -44,3 +45,6 @@ def optimize_thumbnail_task(name, file, storage, thumbnail_options):
         name=name, file=file, storage=storage, thumbnail_options=thumbnail_options
     )
     optimize_thumbnail(thumbnail)
+
+    if settings.FDS_THUMBNAIL_ENABLE_AVIF and name.endswith((".png", ".jpg", ".jpeg")):
+        generate_avif_thumbnail(name, storage)


### PR DESCRIPTION
There was a race-condition between the optimization task re-writing the file and the avif task reading it, leading to the avif task seeing only an empty file and crashing