### PR TITLE
🐛 Fix duplicate document entries

### DIFF
--- a/scripts/create_light_sql.py
+++ b/scripts/create_light_sql.py
@@ -149,11 +149,10 @@ def generate_copy_script(
                     "private = FALSE",
                 ),
             ),
-            ("public.document_document", ("user_id IS NOT NULL",)),
             (
-                "document_document",
+                "public.document_document",
                 (
-                    "id IN (SELECT id FROM document_document WHERE portal_id IS NULL ORDER BY id DESC LIMIT 500)",
+                    "id IN ((SELECT id FROM document_document WHERE portal_id IS NULL AND user_id IS NOT NULL ORDER BY id DESC LIMIT 500) UNION (SELECT id FROM document_document WHERE portal_id IS NOT NULL ORDER BY id DESC LIMIT 500))",
                 ),
             ),
             ("public.document_documentcollection", ("user_id IS NOT NULL",)),


### PR DESCRIPTION
`public.document_document` and `document_document` refer to the same table, which lead to the same documents being dumped and inserted twice. This crashed the admin when viewing the document list