### PR TITLE
Add Playwright tests for Stripe SEPA and CC

### DIFF
--- a/dev.nix
+++ b/dev.nix
@@ -1,7 +1,7 @@
 with import <nixpkgs> { };
 let
   dontCheckPython = drv: drv.overridePythonAttrs (old: { doCheck = false; });
-  pythonPackages = python39Packages;
+  pythonPackages = python310Packages;
 
   harfbuzz_self = harfbuzz.override { withCoreText = true; };
   ld_packages = [
@@ -75,5 +75,7 @@ pkgs.mkShell {
     glib
     libcxx
     cmake
+
+    stripe-cli
   ] ++ (lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.CoreText);
 }

--- a/fragdenstaat_de/fds_donation/tests/README.md
+++ b/fragdenstaat_de/fds_donation/tests/README.md
@@ -1,0 +1,7 @@
+# How to test with Stripe
+
+1. Setup test API keys in `fragdenstaat_de/settings/test.py`
+2. Build frontend with `yarn build`
+3. Run tests in this directory locally with `pytest`
+
+

--- a/fragdenstaat_de/fds_donation/tests/test_stripe.py
+++ b/fragdenstaat_de/fds_donation/tests/test_stripe.py
@@ -100,6 +100,14 @@ class StripeWebhookForwarder:
         return [WebhookEvent(*m.groups()) for m in self.WH_EVENT_RE.finditer(log)]
 
 
+@pytest.fixture(autouse=True)
+def skip_stripe_if_no_key(request, settings):
+    if request.node.get_closest_marker("stripe"):
+        secret_key = settings.PAYMENT_VARIANTS["sepa"][1]["secret_key"]
+        if not secret_key:
+            pytest.skip("skipped stripe test because stripe key is not set")
+
+
 @pytest.fixture
 def stripe_sepa_setup(settings, live_server, monkeypatch):
     settings.SITE_URL = live_server.url

--- a/fragdenstaat_de/fds_donation/tests/test_stripe.py
+++ b/fragdenstaat_de/fds_donation/tests/test_stripe.py
@@ -1,0 +1,456 @@
+import re
+import signal
+import subprocess
+import time
+from collections import namedtuple
+from datetime import datetime
+
+from django.urls import reverse
+
+import payments.core
+import pytest
+import stripe
+from fragdenstaat_de.fds_donation.models import Donation
+from playwright.sync_api import Page
+
+import froide_payment.provider.stripe
+
+WebhookEvent = namedtuple("WebhookEvent", ["timestamp", "name", "event_id"])
+
+STRIPE_TEST_IBANS = {
+    "success": "DE89370400440532013000",
+    "failed": "DE62370400440532013001",
+    "disputed": "DE35370400440532013002",
+    "additional_fields": "CH9300762011623852957",
+}
+STRIPE_TEST_CARDS = {
+    "success": "4242424242424242",
+    "declined": "4000000000000002",
+}
+
+
+class StripeWebhookForwarder:
+    WH_EVENT_RE = re.compile(
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+-->\s+([\w\.]+)\s+\[(\w+)\]"
+    )
+
+    def __init__(self, secret_key: str, forward_url: str):
+        self.secret_key = secret_key
+        self.forward_url = forward_url.replace("http://", "")
+        self.webhooks_called = None
+        self.final_event = None
+        self.final_event_max = 1
+
+    def get_webhook_secret(self):
+        webhook_secret = subprocess.run(
+            ["stripe", "listen", "--api-key", self.secret_key, "--print-secret"],
+            stdout=subprocess.PIPE,
+            check=True,
+            universal_newlines=True,
+        ).stdout.strip()
+        assert re.match(r"^whsec_\w{32,}$", webhook_secret), webhook_secret
+        return webhook_secret
+
+    def set_final_event(self, final_event: str, final_event_max: int = 1):
+        self.final_event = final_event
+        self.final_event_max = final_event_max
+
+    def __enter__(self):
+        process_args = [
+            "stripe",
+            "listen",
+            "--api-key",
+            self.secret_key,
+            "--forward-to",
+            self.forward_url,
+            "--color",
+            "off",
+        ]
+        self.proc = subprocess.Popen(
+            process_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.webhooks_called = []
+        final_event_count = 0
+        found_final_event = False
+        try:
+            if self.proc.returncode is None:
+                for line in self.proc.stdout:
+                    print(line)
+                    if found_final_event:
+                        if "] POST" in line:
+                            break
+                    else:
+                        events = self.make_webhook_events(line)
+                        if not events:
+                            continue
+                        self.webhooks_called.extend(events)
+                        final_event_count += len(
+                            [ev for ev in events if ev.name == self.final_event]
+                        )
+                        if final_event_count >= self.final_event_max:
+                            found_final_event = True
+                self.proc.send_signal(signal.SIGINT)
+                try:
+                    returncode = self.proc.wait(1)
+                except subprocess.TimeoutExpired:
+                    pass
+                else:
+                    if returncode != 0:
+                        raise Exception("Error stopping stripe webhook forwarder")
+            elif exc_val is not None:
+                self.proc.send_signal(signal.SIGKILL)
+        finally:
+            if self.proc.returncode is None:
+                self.proc.send_signal(signal.SIGKILL)
+
+    def make_webhook_events(self, log: str):
+        return [WebhookEvent(*m.groups()) for m in self.WH_EVENT_RE.finditer(log)]
+
+
+@pytest.fixture
+def stripe_sepa_setup(settings, live_server, monkeypatch):
+    settings.SITE_URL = live_server.url
+    # PAYMENT_HOST setting is copied to module level on import, need to patch it
+    monkeypatch.setattr(
+        payments.core, "PAYMENT_HOST", live_server.url.replace("http://", "")
+    )
+    # Disable confirmation checks for testing
+    monkeypatch.setattr(
+        froide_payment.provider.stripe, "requires_confirmation", lambda r, p, d: False
+    )
+
+    secret_key = settings.PAYMENT_VARIANTS["sepa"][1]["secret_key"]
+    assert secret_key.startswith("sk_test_")
+    stripe.api_key = secret_key
+
+    webhook_url = live_server.url + "/payments/process/sepa/"
+    forwarder = StripeWebhookForwarder(secret_key, webhook_url)
+    settings.PAYMENT_VARIANTS["sepa"][1][
+        "signing_secret"
+    ] = forwarder.get_webhook_secret()
+    yield forwarder
+
+
+def fill_donation_page(page: Page, donor_email):
+    page.get_by_placeholder("Vorname").fill("Peter")
+    page.get_by_placeholder("Nachname").fill("Parker")
+    page.get_by_placeholder("z.B. name@beispiel.de").fill(donor_email)
+    page.get_by_text("Nein, danke.").nth(1).click()
+    page.get_by_text("Nein, danke.").nth(2).click()
+    page.get_by_label("Was ist drei plus vier?").fill("7")
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_sepa_recurring_donation_success(page: Page, live_server, stripe_sepa_setup):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    page.get_by_text("monatlich").click()
+    page.get_by_text("SEPA-Lastschrift", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.final_event = "invoice.payment_succeeded"
+
+    with stripe_sepa_setup:
+        page.locator("#id_iban").fill(STRIPE_TEST_IBANS["success"])
+        page.get_by_role("button", name="Jetzt spenden").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    stripe_event_id = [
+        event.event_id
+        for event in stripe_sepa_setup.webhooks_called
+        if event.name == "payment_intent.succeeded"
+    ][0]
+    event = stripe.Event.retrieve(stripe_event_id)
+    mandate_id = event.data.object.charges.data[
+        0
+    ].payment_method_details.sepa_debit.mandate
+    mandate = stripe.Mandate.retrieve(mandate_id)
+    assert mandate.status == "active"
+    assert mandate.type == "multi_use"
+    assert mandate.payment_method_details.type == "sepa_debit"
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=True
+    ).latest("timestamp")
+    payment = donation.payment
+    assert payment.status == "confirmed"
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_sepa_once_donation_additional_fields(
+    page: Page, live_server, stripe_sepa_setup
+):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    page.get_by_text("SEPA-Lastschrift", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.final_event = "charge.succeeded"
+
+    with stripe_sepa_setup:
+        page.locator("#id_iban").fill(STRIPE_TEST_IBANS["additional_fields"])
+        page.get_by_role("button", name="Jetzt spenden").click()
+
+        page.get_by_placeholder("Adresse").fill("Teststraße 1")
+        page.get_by_placeholder("Ort").fill("Zürich")
+        page.get_by_placeholder("Postleitzahl").fill("1234")
+
+        page.get_by_role("button", name="Jetzt spenden").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    stripe_event_id = [
+        event.event_id
+        for event in stripe_sepa_setup.webhooks_called
+        if event.name == "payment_intent.succeeded"
+    ][0]
+    event = stripe.Event.retrieve(stripe_event_id)
+    mandate_id = event.data.object.charges.data[
+        0
+    ].payment_method_details.sepa_debit.mandate
+    mandate = stripe.Mandate.retrieve(mandate_id)
+
+    assert mandate.status == "inactive"
+    assert mandate.type == "single_use"
+    assert mandate.payment_method_details.type == "sepa_debit"
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=False
+    ).latest("timestamp")
+    assert donation.recurring is False
+    assert donation.payment.status == "confirmed"
+    assert donation.order.subscription is None
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_sepa_recurring_donation_failed(page: Page, live_server, stripe_sepa_setup):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    page.get_by_text("monatlich").click()
+    page.get_by_text("SEPA-Lastschrift", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.set_final_event("customer.subscription.updated", 2)
+    with stripe_sepa_setup:
+        page.locator("#id_iban").fill(STRIPE_TEST_IBANS["failed"])
+        page.get_by_role("button", name="Jetzt spenden").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    stripe_event_id = [
+        event.event_id
+        for event in stripe_sepa_setup.webhooks_called
+        if event.name == "payment_intent.payment_failed"
+    ][0]
+    event = stripe.Event.retrieve(stripe_event_id)
+    charge = event.data.object.charges.data[0]
+    assert charge.status == "failed"
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=True
+    ).latest("timestamp")
+    payment = donation.payment
+    assert payment.status == "error"
+    assert donation.amount_received == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_sepa_once_donation_disputed(page: Page, live_server, stripe_sepa_setup):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    page.get_by_text("SEPA-Lastschrift", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.final_event = "charge.dispute.closed"
+
+    with stripe_sepa_setup:
+        page.locator("#id_iban").fill(STRIPE_TEST_IBANS["disputed"])
+        page.get_by_role("button", name="Jetzt spenden").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=False
+    ).latest("timestamp")
+    payment = donation.payment
+    assert payment.status == "rejected"
+    assert payment.received_amount == 0
+    assert donation.amount_received == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_creditcard_recurring_donation_success(
+    page: Page, live_server, stripe_sepa_setup
+):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    page.get_by_text("monatlich").click()
+    page.get_by_text("Kreditkarte", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.final_event = "invoice.payment_succeeded"
+
+    with stripe_sepa_setup:
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').locator(
+            ".CardField-restWrapper"
+        ).click()
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "Kartennummer"
+        ).fill(STRIPE_TEST_CARDS["success"])
+        next_year = datetime.now().year + 1
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "MM/JJ"
+        ).fill("12 / {}".format(next_year))
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "Prüfziffer"
+        ).fill("123")
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "PLZ"
+        ).click()
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "PLZ"
+        ).fill("12345")
+
+        page.get_by_role("button").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=True
+    ).latest("timestamp")
+    payment = donation.payment
+    assert payment.status == "confirmed"
+    assert donation.order.subscription is not None
+
+
+@pytest.mark.django_db
+@pytest.mark.stripe
+def test_creditcard_once_donation_success(page: Page, live_server, stripe_sepa_setup):
+    donor_email = "peter.parker@example.com"
+
+    page.goto(live_server.url + reverse("fds_donation:donate"))
+    page.get_by_role("button", name="5 Euro").click()
+    # page.get_by_text("monatlich").click()
+    page.get_by_text("Kreditkarte", exact=True).click()
+    fill_donation_page(page, donor_email)
+    page.get_by_role("button", name="Jetzt spenden").click()
+
+    stripe_sepa_setup.final_event = "charge.succeeded"
+
+    with stripe_sepa_setup:
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').locator(
+            ".CardField-restWrapper"
+        ).click()
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "Kartennummer"
+        ).fill(STRIPE_TEST_CARDS["success"])
+        next_year = datetime.now().year + 1
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "MM/JJ"
+        ).fill("12 / {}".format(next_year))
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "Prüfziffer"
+        ).fill("123")
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "PLZ"
+        ).click()
+        page.frame_locator('iframe[name^="__privateStripeFrame"]').get_by_placeholder(
+            "PLZ"
+        ).fill("12345")
+
+        page.get_by_role("button").click()
+
+        page.wait_for_url("**spenden/spende/spenden/abgeschlossen/**")
+
+        assert page.get_by_text("Vielen Dank für Ihre Spende!").is_visible()
+        assert page.get_by_text(donor_email).is_visible()
+
+        print("waiting for webhooks to complete...")
+
+    webhooks = [webhook.name for webhook in stripe_sepa_setup.webhooks_called]
+    print(webhooks)
+
+    # Wait for webhooks to be processed by live server
+    time.sleep(2)
+    donation = Donation.objects.filter(
+        donor__email=donor_email, amount=5, recurring=False
+    ).latest("timestamp")
+    payment = donation.payment
+    assert payment.status == "confirmed"
+    assert donation.order.subscription is None

--- a/fragdenstaat_de/fds_donation/tests/utils.py
+++ b/fragdenstaat_de/fds_donation/tests/utils.py
@@ -1,0 +1,63 @@
+import select
+import signal
+import subprocess
+import threading
+from queue import Queue
+
+
+def subprocess_reader(process_args, stop_event, queue):
+    proc = subprocess.Popen(
+        process_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+
+    poll_obj = select.poll()
+    poll_obj.register(proc.stdout, select.POLLIN)
+    while True:
+        if stop_event.is_set():
+            break
+        poll_result = poll_obj.poll(1)
+        if poll_result:
+            line = proc.stdout.readline()
+            if line:
+                queue.put(line)
+        returncode = proc.poll()
+        if returncode is not None:
+            break
+    poll_obj.unregister(proc.stdout)
+    proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+class ProcessReader:
+    def __init__(self, process_args):
+        self.process_args = process_args
+        self.thread = None
+        self.queue = Queue()
+        self.stop_event = threading.Event()
+
+    def start(self):
+        if self.thread:
+            raise Exception("Process already started")
+        self.thread = threading.Thread(
+            target=subprocess_reader,
+            args=(self.process_args, self.stop_event, self.queue),
+        )
+        self.thread.start()
+        return self
+
+    def readline(self):
+        if not self.thread:
+            raise Exception("Process not started")
+        return self.queue.get()
+
+    def stop(self):
+        if not self.thread:
+            raise Exception("Process not started")
+        self.stop_event.set()
+        self.thread.join()

--- a/fragdenstaat_de/fds_donation/views.py
+++ b/fragdenstaat_de/fds_donation/views.py
@@ -74,6 +74,11 @@ class DonationCompleteView(TemplateView):
 class DonationFailedView(TemplateView):
     template_name = "fds_donation/donation_failed.html"
 
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["donate_url"] = reverse("fds_donation:donate")
+        return ctx
+
 
 class DonorMixin:
     model = Donor

--- a/fragdenstaat_de/settings/test.py
+++ b/fragdenstaat_de/settings/test.py
@@ -2,7 +2,7 @@ import os
 
 from configurations import values
 
-from .base import THEME_ROOT, FragDenStaatBase
+from .base import THEME_ROOT, FragDenStaatBase, env
 
 
 class Test(FragDenStaatBase):
@@ -37,3 +37,29 @@ class Test(FragDenStaatBase):
         "default": {"hosts": "http://localhost:9200"},
     }
     FIXTURE_DIRS = [os.path.join(THEME_ROOT, "..", "tests", "fixtures")]
+
+    PAYMENT_VARIANTS = {
+        # 'default': ('payments.dummy.DummyProvider', {})
+        "creditcard": (
+            "froide_payment.provider.StripeIntentProvider",
+            {
+                # Test API keys
+                "public_key": env("STRIPE_TEST_PUBLIC_KEY"),
+                "secret_key": env("STRIPE_TEST_SECRET_KEY"),
+            },
+        ),
+        "sepa": (
+            "froide_payment.provider.StripeSEPAProvider",
+            {
+                # Test API keys
+                "public_key": env("STRIPE_TEST_PUBLIC_KEY"),
+                "secret_key": env("STRIPE_TEST_SECRET_KEY"),
+            },
+        ),
+        "paypal": (
+            "froide_payment.provider.PaypalProvider",
+            {},
+        ),
+        "lastschrift": ("froide_payment.provider.LastschriftProvider", {}),
+        "banktransfer": ("froide_payment.provider.BanktransferProvider", {}),
+    }

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ DJANGO_CONFIGURATION=Test
 DJANGO_SETTINGS_MODULE = fragdenstaat_de.settings.test
 python_files = tests.py test_*.py *_tests.py
 testpaths = fragdenstaat_de tests
+addopts = --reuse-db

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,6 @@ DJANGO_CONFIGURATION=Test
 DJANGO_SETTINGS_MODULE = fragdenstaat_de.settings.test
 python_files = tests.py test_*.py *_tests.py
 testpaths = fragdenstaat_de tests
-addopts = --reuse-db
+addopts = --reuse-db -m "not stripe"
+markers =
+    stripe: Run donation tests with stripe test keys


### PR DESCRIPTION
- Ensure `stripe` CLI is installed.
- Have the secrets in `PAYMENT_VARIANTS` loaded in `settings/test.py` in your environment
- Run e.g. via `pytest -v --headed -s -m stripe`