### PR TITLE
Revert "Render frontend dependencies via CMS when toolbar present"

### DIFF
--- a/fragdenstaat_de/templates/_frontend.html
+++ b/fragdenstaat_de/templates/_frontend.html
@@ -1,5 +1,5 @@
 {% load frontendbuild sekizai_tags %}
-{% if request.current_page or force_cms_render or request.toolbar %}
+{% if request.current_page or force_cms_render %}
     {% getfrontendbuild entry_point as assets %}
     {% for block, output_list in assets %}
         {% for output in output_list %}


### PR DESCRIPTION
This reverts commit f42b04d4112f8ce49944df4acd1b18f1696d7732.