### PR TITLE
🔧 disable dependabot for frontend deps for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
+  # TODO: wait until pnpm issues with git repos are fixed
+  # - package-ecosystem: npm
+  #   directory: /
+  #   schedule:
+  #     interval: weekly
   - package-ecosystem: pip
     directory: /
     schedule:


### PR DESCRIPTION
dependabot creates corrupt lock file entries for git dependencies. wait until that issue is resolved. see https://github.com/dependabot/dependabot-core/issues/10124
