### PR TITLE
✨ add share links to article page

### DIFF
--- a/fragdenstaat_de/fds_blog/models.py
+++ b/fragdenstaat_de/fds_blog/models.py
@@ -482,6 +482,12 @@ class Article(
     def get_full_url(self):
         return "%s%s" % (settings.SITE_URL, self.get_absolute_url())
 
+    def get_short_url(self):
+        return "%s%s" % (
+            settings.SITE_URL,
+            reverse("blog-redirects:article-short-url", kwargs={"pk": self.pk}),
+        )
+
     def other_languages(self):
         if not hasattr(self, "_other_languages"):
             if self.uuid is None:

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/_article_detail.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/_article_detail.html
@@ -13,10 +13,13 @@
                 {% if article.teaser %}
                     <div class="lead">{% render_model article "teaser" "" "" "safe" %}</div>
                 {% endif %}
-                <div class="mt-5">
-                    {% with authors=article.get_authors %}
-                        {% include "fds_blog/includes/_authors.html" %}
-                    {% endwith %}
+                <div class="d-flex mt-5 align-items-center">
+                    <div>
+                        {% with authors=article.get_authors %}
+                            {% include "fds_blog/includes/_authors.html" %}
+                        {% endwith %}
+                    </div>
+                    <div class="d-none d-md-block ms-auto">{% include "fds_blog/includes/share_article.html" %}</div>
                 </div>
             </div>
         </div>
@@ -69,6 +72,14 @@
 {% endblock article_content %}
 {% block article_footer %}
     <footer class="mb-3">
+        <section>
+            <div class="container-lg">
+                <div class="d-md-flex align-items-center">
+                    <h3 class="small text-secondary m-0 me-md-3">{% trans "Share article" %}</h3>
+                    {% include "fds_blog/includes/share_article.html" %}
+                </div>
+            </div>
+        </section>
         <section>
             {% block article_author_bios %}
                 <div class="container-lg">

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/includes/share_article.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/includes/share_article.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+{% trans "Copy short link" as copy_text %}
+{% include "snippets/share_buttons.html" with text=article.meta_title links=True url=article.get_full_url short_url=article.get_short_url copy_text=copy_text %}

--- a/fragdenstaat_de/theme/urls.py
+++ b/fragdenstaat_de/theme/urls.py
@@ -117,7 +117,7 @@ urlpatterns += i18n_patterns(
     *froide_urlpatterns,
     *jurisdiction_urls,
     *admin_urls,
-    path("", include("fragdenstaat_de.fds_blog.redirect_urls")),
+    path("", include("fragdenstaat_de.fds_blog.redirect_urls"), name="blog-redirects"),
     path("", include("fragdenstaat_de.fds_ogimage.urls")),
     path(pgettext_lazy("url part", "campaign/"), include(campaign_urls)),
     path("", include("cms.urls")),


### PR DESCRIPTION
adds share links to the header (only on desktop):
![at the top](https://github.com/user-attachments/assets/e5601f76-7bae-4757-9871-2f22545b3bb9)

and the footer:
![at the bottom](https://github.com/user-attachments/assets/893041ec-2eeb-400a-bc3d-eecd5cd9cf45)
