### PR TITLE
support exposing dev server on local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ cd fragdenstaat_de
 pnpm run dev
 ```
 
+To do frontend development on your local network,
+e.g. to allow mobile devices to access the dev server,
+at http://myhost.mylocaldomain in this example:
+
+- check `Dev.__init__` in `local_settings.py.example`
+  and copy/uncomment the relevant parts
+- run `python manage.py runserver myhost.mylocaldomain:8000`
+- run `pnpm run serve --host=myhost.mylocaldomain` (instead of `pnpm run dev`)
+
 ### Upgrade dependencies
 
 ```bash

--- a/fragdenstaat_de/settings/local_settings.py.example
+++ b/fragdenstaat_de/settings/local_settings.py.example
@@ -2,6 +2,16 @@ from .base import FragDenStaatBase
 
 
 class Dev(FragDenStaatBase):
+    # uncomment to support exposing to local network
+    # def __init__(self):
+    #     # check for argument after: manage.py runserver ...
+    #     if len(sys.argv) > 2:
+    #         # grab host after runserver ...
+    #         host = sys.argv[2]
+    #         self.SITE_URL = 'http://' + host
+    #         self.FRONTEND_SERVER_URL = 'http://' + host.replace('8000', '5173') +'/'
+    #         self.ALLOWED_HOSTS = ('*', host, )
+
     DEBUG = True
     ALLOWED_HOSTS = ('*',)
     # CELERY_TASK_ALWAYS_EAGER = False


### PR DESCRIPTION
maybe useful to other people; if not, feel free to reject and I'll just keep it local.

- the `Dev.__init__` part could be uncommented ootb, it has no effect if you don't specifiy a host for `runserver`
- this is probably not idiomatic python or django :\