### PR TITLE
Run fximport in background task

### DIFF
--- a/fragdenstaat_de/fds_fximport/askfx.py
+++ b/fragdenstaat_de/fds_fximport/askfx.py
@@ -269,7 +269,7 @@ class FrontexPadClient:
         req.raise_for_status()
         return req
 
-    def _login(self, retries: int = 100) -> str:
+    def _login(self, retries: int = 500) -> str:
         """Load the login form and return a path to the captcha iamge
 
         Returns:

--- a/fragdenstaat_de/fds_fximport/tasks.py
+++ b/fragdenstaat_de/fds_fximport/tasks.py
@@ -1,15 +1,70 @@
+import logging
+
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+
 from froide.celery import app as celery_app
+from froide.foirequest.models import FoiMessage
+from froide.foirequest.models.message import MessageKind
+from froide.foirequest.utils import send_request_user_email
+from froide.helper.email_sending import mail_registry
 
 from . import helper
+
+logger = logging.getLogger(__name__)
+
+fximport_success_mail = mail_registry.register(
+    "fds_fximport/emails/success",
+    ("action_url", "foirequest", "message", "user"),
+)
+
+fximport_failed_mail = mail_registry.register(
+    "fds_fximport/emails/failed",
+    ("action_url", "foirequest", "message", "user"),
+)
 
 
 @celery_app.task(name="fragdenstaat_de.fds_fximport.import_case")
 def import_case(message_id):
-    from froide.foirequest.models import FoiMessage
+    with transaction.atomic():
+        try:
+            message = FoiMessage.objects.get(id=message_id)
+        except FoiMessage.DoesNotExist:
+            return
+        try:
+            helper.import_frontex_case(message)
+            newest_fx_message = (
+                FoiMessage.objects.filter(request=message.request)
+                .filter(kind=MessageKind.IMPORT)
+                .last()
+            )
 
-    try:
-        message = FoiMessage.objects.get(id=message_id)
-    except FoiMessage.DoesNotExist:
-        return
+            send_request_user_email(
+                fximport_success_mail,
+                message.request,
+                subject=_("New Message imported"),
+                context={
+                    "message": message,
+                    "foirequest": message.request,
+                    "user": message.request.user,
+                    "action_url": message.request.user.get_autologin_url(
+                        newest_fx_message.get_absolute_short_url()
+                    ),
+                },
+            )
 
-    helper.import_frontex_case(message)
+        except Exception:
+            logger.exception("Frontex import failed")
+            send_request_user_email(
+                fximport_failed_mail,
+                message.request,
+                subject=_("Message import failed"),
+                context={
+                    "message": message,
+                    "foirequest": message.request,
+                    "user": message.request.user,
+                    "action_url": message.request.user.get_autologin_url(
+                        message.get_absolute_short_url()
+                    ),
+                },
+            )

--- a/fragdenstaat_de/fds_fximport/views.py
+++ b/fragdenstaat_de/fds_fximport/views.py
@@ -3,12 +3,11 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
-from sentry_sdk import capture_exception
-
 from froide.foirequest.models import FoiMessage
 from froide.foirequest.views.request_actions import allow_write_foirequest
 
-from .helper import import_frontex_case, is_frontex_msg
+from .helper import is_frontex_msg
+from .tasks import import_case
 
 
 @require_POST
@@ -22,19 +21,11 @@ def frontex_pad_import(request, foirequest, message_id):
         )
         return redirect(foirequest)
 
-    try:
-        import_frontex_case(message)
-        messages.add_message(
-            request,
-            messages.SUCCESS,
-            _("Import successful."),
-        )
-    except Exception as e:
-        messages.add_message(
-            request,
-            messages.ERROR,
-            _("Something went wrong. Please try again later."),
-        )
-        capture_exception(e)
+    import_case.delay(message.pk)
+    messages.add_message(
+        request,
+        messages.SUCCESS,
+        _("Import stated. You will receive an email once it finishes."),
+    )
 
     return redirect(foirequest)


### PR DESCRIPTION
Previously we ran the importer inside the request handler, which sometimes generated timeout if many / large files were imported or the captcha solving took too long. This PR changes this to only start a task in the request handler which then runs fximport in the background and sends an email to the user on success / failure
