### PR TITLE
🔧 Disable Frontex import button instead of hiding it

### DIFF
--- a/fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
+++ b/fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
@@ -2,7 +2,7 @@
 {% load static %}
 <div class="btn-group btn-group-sm mb-1 ms-sm-auto">
     <span class="btn-group btn-group-sm"
-          {% if is_imported %} title="{% translate 'This message has already been imported from Frontex.' %}" {% endif %}>
+          {% if is_imported %} title="{% translate 'This message has already been imported from Frontex.' %}" data-bs-toggle="tooltip"{% endif %}>
         <button class="btn btn-primary"
                 data-bs-toggle="modal"
                 data-bs-target="#frontex-pad-import-modal-{{ message.id }}"

--- a/fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
+++ b/fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 {% load static %}
 <div class="btn-group btn-group-sm mb-1 ms-sm-auto">
-    <button class="btn btn-primary"
-            data-bs-toggle="modal"
-            data-bs-target="#frontex-pad-import-modal-{{ message.id }}">
-        {% blocktrans %}
-  Import Message from Frontex
-  {% endblocktrans %}
-    </button>
+    <span class="btn-group btn-group-sm"
+          {% if is_imported %} title="{% translate 'This message has already been imported from Frontex.' %}" {% endif %}>
+        <button class="btn btn-primary"
+                data-bs-toggle="modal"
+                data-bs-target="#frontex-pad-import-modal-{{ message.id }}"
+                {% if is_imported %}disabled{% endif %}>{% translate 'Import Message from Frontex' %}</button>
+    </span>
 </div>
 <div data-teleport="body"
      class="modal fade modal-lg"
@@ -24,7 +24,7 @@
                 <button type="button"
                         class="btn-close"
                         data-dismiss="modal"
-                        aria-label="{% translate "Close" %}"></button>
+                        aria-label="{% translate 'Close' %}"></button>
             </div>
             <div class="modal-body">
                 <form id="frontex-import-form"
@@ -44,7 +44,7 @@
                     </p>
                     <p class="text-center show-while-submitting">
                         <img id="workingGif"
-                             alt="{% trans "Gif of a cat furiously typing on a keyboard" %}"
+                             alt="{% trans 'Gif of a cat furiously typing on a keyboard' %}"
                              src="{% static 'fds_fximport/keyboard-cat.gif' %}" />
                     </p>
                 </form>

--- a/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
+++ b/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
@@ -2465,15 +2465,13 @@ msgstr ""
 "Beste Grüße\n"
 "%(site_name)s"
 
-#: fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
-msgid ""
-"\n"
-"  Import Message from Frontex\n"
-"  "
-msgstr ""
-"\n"
-"  Nachricht von Frontex importieren\n"
-"  "
+#: fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html:6
+msgid "This message has already been imported from Frontex."
+msgstr "Diese Nachricht wurde bereits von Frontex importiert."
+
+#: fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html:12
+msgid "Import Message from Frontex"
+msgstr "Nachricht von Frontex importieren"
 
 #: fragdenstaat_de/fds_fximport/templates/fds_fximport/import_frag.html
 msgid "Message from Frontex"

--- a/fragdenstaat_de/templates/foirequest/body/message/message.html
+++ b/fragdenstaat_de/templates/foirequest/body/message/message.html
@@ -24,7 +24,7 @@
         {% endif %}
     {% endif %}
     {% if message|needs_frontex_import:request.user %}
-        {% include "fds_fximport/import_frag.html" with request=object message=message %}
+        {% include "fds_fximport/import_frag.html" with request=object message=message is_imported=message|is_frontex_imported %}
     {% endif %}
     {% if message|needs_glyphosat_attachment %}
         <button class="btn btn-primary btn-sm mb-1 mx-sm-1"

--- a/fragdenstaat_de/templates/foirequest/body/message/message.html
+++ b/fragdenstaat_de/templates/foirequest/body/message/message.html
@@ -23,7 +23,7 @@
             {% include "froide_fax/_show_report_link.html" %}
         {% endif %}
     {% endif %}
-    {% if message|needs_frontex_import:request.user %}
+    {% if message|is_frontex_message:request.user %}
         {% include "fds_fximport/import_frag.html" with request=object message=message is_imported=message|is_frontex_imported %}
     {% endif %}
     {% if message|needs_glyphosat_attachment %}

--- a/fragdenstaat_de/theme/templatetags/fds_tags.py
+++ b/fragdenstaat_de/theme/templatetags/fds_tags.py
@@ -21,6 +21,9 @@ def needs_glyphosat_attachment(message):
 
 @register.filter
 def needs_frontex_import(message, user):
-    if IMPORTED_TAG in message.tag_set:
-        return False
     return is_frontex_msg(message)
+
+
+@register.filter
+def is_frontex_imported(message):
+    return IMPORTED_TAG in message.tag_set

--- a/fragdenstaat_de/theme/templatetags/fds_tags.py
+++ b/fragdenstaat_de/theme/templatetags/fds_tags.py
@@ -20,7 +20,7 @@ def needs_glyphosat_attachment(message):
 
 
 @register.filter
-def needs_frontex_import(message, user):
+def is_frontex_message(message, user):
     return is_frontex_msg(message)
 
 


### PR DESCRIPTION
Instead of hiding the Frontex import button after a message has been imported, we now disable it and show a tooltip explaining why. This improves UX by:
- Making the button's state more visible to users
- Providing clear feedback about why the action is not available

Changes:
- Add is_frontex_imported template filter
- Update import button to show disabled state with tooltip
- Pass import status to template
- Clean up template code and translations

closes fragdenstaat/issues#17