### PR TITLE
paperless fixes

### DIFF
--- a/fragdenstaat_de/fds_paperless/paperless.py
+++ b/fragdenstaat_de/fds_paperless/paperless.py
@@ -72,15 +72,6 @@ def get_correspondents():
     return data["results"]
 
 
-def get_thumbnail(paperless_document_id: int) -> tuple[str, bytes]:
-    client = get_paperless_client()
-    THUMBNAIL_URL = (
-        settings.PAPERLESS_API_URL + f"/documents/{paperless_document_id}/thumb/"
-    )
-    thumbnail = client.get(THUMBNAIL_URL)
-    return thumbnail.headers.get("Content-Type", ""), thumbnail.content
-
-
 def add_tag_to_documents(paperless_document_ids: list[int], foirequest):
     client = get_paperless_client()
 

--- a/fragdenstaat_de/fds_paperless/urls.py
+++ b/fragdenstaat_de/fds_paperless/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from .views import (
     get_pdf_view,
-    get_thumbnail_view,
     list_view,
     select_documents_view,
 )
@@ -14,6 +13,5 @@ urlpatterns = [
         select_documents_view,
         name="paperless_import",
     ),
-    path("thumb/<int:paperless_document>/", get_thumbnail_view, name="paperless_thumb"),
     path("pdf/<int:paperless_document>/", get_pdf_view, name="paperless_pdf"),
 ]

--- a/fragdenstaat_de/fds_paperless/views.py
+++ b/fragdenstaat_de/fds_paperless/views.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.decorators.cache import cache_control
 
 from froide.foirequest.auth import can_write_foirequest
 from froide.foirequest.models import FoiRequest
@@ -69,7 +68,6 @@ def select_documents_view(request, foirequest):
 
 
 @require_crew
-@cache_control(max_age=86400)
 def get_pdf_view(request, paperless_document: int):
     content = get_document_data(paperless_document_id=paperless_document)
     return HttpResponse(content, content_type="application/pdf")

--- a/fragdenstaat_de/fds_paperless/views.py
+++ b/fragdenstaat_de/fds_paperless/views.py
@@ -14,7 +14,6 @@ from .paperless import (
     add_tag_to_documents,
     get_document_data,
     get_documents_by_correspondent,
-    get_thumbnail,
 )
 
 User = get_user_model()
@@ -67,13 +66,6 @@ def select_documents_view(request, foirequest):
         "fds_paperless/select_documents.html",
         {"foirequest": foirequest, "documents": paperless_docs, "form": form},
     )
-
-
-@require_crew
-@cache_control(max_age=86400)
-def get_thumbnail_view(request, paperless_document: int):
-    content_type, content = get_thumbnail(paperless_document_id=paperless_document)
-    return HttpResponse(content, content_type=content_type)
 
 
 @require_crew


### PR DESCRIPTION
- **⚰️ remove unneeded paperless views**
- **🩹 don't cache pdf, leads to confusion when editing in paperless**
- **🐛 fix request field not being applied properly**
