### PR TITLE
✨ add paperless recipient group to specify additional users

### DIFF
--- a/fragdenstaat_de/fds_paperless/views.py
+++ b/fragdenstaat_de/fds_paperless/views.py
@@ -20,7 +20,9 @@ User = get_user_model()
 
 @require_crew
 def list_view(request):
-    users = User.objects.filter(groups__in=[settings.CREW_GROUP]).order_by("first_name")
+    users = User.objects.filter(
+        groups__in=[settings.CREW_GROUP, settings.PAPERLESS_RECIPIENT_GROUP]
+    ).order_by("first_name")
     return render(
         request,
         "fds_paperless/list_users.html",

--- a/fragdenstaat_de/settings/base.py
+++ b/fragdenstaat_de/settings/base.py
@@ -903,6 +903,7 @@ class FragDenStaatBase(German, Base):
     PAPERLESS_REQUEST_FIELD = os.environ.get(
         "PAPERLESS_REQUEST_FIELD", ""
     )  # custom_field id for foirequest reference
+    PAPERLESS_RECIPIENT_GROUP = 57
 
     LEAFLET_CONFIG = {
         "TILES": [


### PR DESCRIPTION
previously, only crew members could be recipients of paperless imports
