### PR TITLE
✨ add consent banner for video embeds

### DIFF
--- a/fragdenstaat_de/fds_blog/templates/fds_blog/includes/blog_picture_small.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/includes/blog_picture_small.html
@@ -3,7 +3,7 @@
 <figure class="blog-visual">
     <picture>
         {% thumbnail picture 540x0 crop=smart subject_location=picture.subject_location as thumb %}
-            <source srcset="{{ thumb.url }}.avif" type="image/avif" />
-            <img class="img-fluid" loading="lazy" src="{{ thumb.url }}" {% if not attributes.alt %}alt="{{ picture.default_alt_text|default:"" }}"{% endif %} {{ attributes_str }}>
-        </picture>
-    </figure>
+        <source srcset="{{ thumb.url }}.avif" type="image/avif" />
+        <img class="img-fluid" loading="lazy" src="{{ thumb.url }}" {% if not attributes.alt %}alt="{{ picture.default_alt_text|default:"" }}"{% endif %} {{ attributes_str }}>
+    </picture>
+</figure>

--- a/fragdenstaat_de/fds_cms/cms_plugins.py
+++ b/fragdenstaat_de/fds_cms/cms_plugins.py
@@ -815,5 +815,5 @@ class ExternalPixelPlugin(CMSPluginBase):
         request = context["request"]
         context["pixel_urls"] = instance.get_pixel_urls(request)
         context["cookie_group"] = instance.cookie_group
-        context["cookie_group_data"] = [instance.cookie_group.for_json()]
+        context["cookie_groups"] = [instance.cookie_group]
         return super().render(context, instance, placeholder)

--- a/fragdenstaat_de/fds_cms/templates/cms/plugins/primarylink/_picture.html
+++ b/fragdenstaat_de/fds_cms/templates/cms/plugins/primarylink/_picture.html
@@ -5,19 +5,19 @@
             {# TODO: duplicate of blog_feature_item  #}
             <picture>
                 {% thumbnail picture 640x370 crop subject_location=picture.subject_location as thumb %}
-                    <source media="(min-width: 992px)"
-                            srcset="{{ thumb.url }}.avif"
-                            type="image/avif" />
-                    <source media="(min-width: 992px)" srcset="{{ thumb.url }}" />
-                    {% thumbnail picture 480x277 crop subject_location=picture.subject_location as thumb %}
-                        <source media="(min-width: 768px)"
-                                srcset="{{ thumb.url }}.avif"
-                                type="image/avif" />
-                        <source media="(min-width: 768px)" srcset="{{ thumb.url }}" />
-                        {% thumbnail picture 320x185 crop subject_location=picture.subject_location as thumb %}
-                            <source srcset="{{ thumb.url }}.avif" type="image/avif" />
-                            <img class="w-100 h-auto {{ extra_classes }}" loading="lazy" width="320" height="185" src="{{ thumb.url }}" {% if not attributes.alt %}alt="{{ picture.default_alt_text|default:picture.description|default:"" }}"{% endif %} {{ attributes_str }}>
-                        </picture>
-                    {% endwith %}
-                    {% if object.link %}</a>{% endif %}
-            {% endif %}
+                <source media="(min-width: 992px)"
+                        srcset="{{ thumb.url }}.avif"
+                        type="image/avif" />
+                <source media="(min-width: 992px)" srcset="{{ thumb.url }}" />
+                {% thumbnail picture 480x277 crop subject_location=picture.subject_location as thumb %}
+                <source media="(min-width: 768px)"
+                        srcset="{{ thumb.url }}.avif"
+                        type="image/avif" />
+                <source media="(min-width: 768px)" srcset="{{ thumb.url }}" />
+                {% thumbnail picture 320x185 crop subject_location=picture.subject_location as thumb %}
+                <source srcset="{{ thumb.url }}.avif" type="image/avif" />
+                <img class="w-100 h-auto {{ extra_classes }}" loading="lazy" width="320" height="185" src="{{ thumb.url }}" {% if not attributes.alt %}alt="{{ picture.default_alt_text|default:picture.description|default:"" }}"{% endif %} {{ attributes_str }}>
+            </picture>
+        {% endwith %}
+        {% if object.link %}</a>{% endif %}
+{% endif %}

--- a/fragdenstaat_de/fds_cms/templates/cms/plugins/primarylink/tile.html
+++ b/fragdenstaat_de/fds_cms/templates/cms/plugins/primarylink/tile.html
@@ -10,6 +10,6 @@
                         type="{{ source.mime_type }}" />
             {% endfor %}
             <img class="img-fluid {{ object.attributes.class }}" loading="lazy" width="{{ picture.width|floatformat:"0u" }}" height="{{ picture.height|floatformat:"0u" }}" src="{{ respimg.src }}" srcset="{{ respimg.srcset }}" sizes="{{ respimg.sizes }}" {% if not attributes.alt %}alt="{{ picture.default_alt_text|default:"" }}"{% endif %} {{ instance.attributes_str }}>
-        </picture>
-    {% endwith %}
+        {% endwith %}
+    </picture>
 </a>

--- a/fragdenstaat_de/fds_cms/templates/fds_cms/external_pixel.html
+++ b/fragdenstaat_de/fds_cms/templates/fds_cms/external_pixel.html
@@ -1,40 +1,46 @@
 {% load static i18n cookie_consent_tags sekizai_tags %}
 {% load markup %}
-{% addtoblock "js" %}
 {% url 'cookie_consent_status' as status_url %}
-{% url "cookie_consent_cookie_group_list" as url_cookies %}
-<template id="cookie-consent__cookie-bar" data-cookiestatus="{{ status_url }}">
-    <div class="modal"
-         tabindex="-1"
-         id="cookie-consent__modal"
-         role="dialog"
-         data-bs-backdrop="static"
-         data-bs-keyboard="false"
-         aria-labelledby="cookie-consent__modal-label"
-         aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 id="cookie-consent__modal-label" class="modal-title">{{ cookie_group.name }}</h5>
-                </div>
-                <div class="modal-body">{{ cookie_group.description|markdown }}</div>
-                <div class="modal-footer">
-                    <button type="button"
-                            id="cookie-consent__decline"
-                            class="btn btn-outline-secondary">{% translate "Decline" %}</button>
-                    <button type="button" id="cookie-consent__accept" class="btn btn-primary">{% translate "Accept" %}</button>
+<div class="cookie-consent"
+     data-cookie-group="{{ cookie_group.varname }}"
+     data-status-url="{{ status_url }}"
+     data-accept-url="{% cookie_consent_accept_url cookie_groups %}"
+     data-decline-url="{% cookie_consent_decline_url cookie_groups %}">
+    <template class="cookie-consent__message">
+        <div class="modal"
+             tabindex="-1"
+             role="dialog"
+             data-bs-backdrop="static"
+             data-bs-keyboard="false"
+             aria-labelledby="consent-label-{{ instance.pk }}"
+             aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 id="consent-label-{{ instance.pk }}" class="modal-title">{{ cookie_group.name }}</h5>
+                    </div>
+                    <div class="modal-body">{{ cookie_group.description|markdown }}</div>
+                    <div class="modal-footer">
+                        <button type="button"
+                                class="btn btn-outline-secondary cookie-consent__decline">
+                            {% translate "Decline" %}
+                        </button>
+                        <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-</template>
-{% endaddtoblock %}
-{% addtoblock "js" %}
-{{ cookie_group_data|json_script:"cookie-consent__cookie-groups" }}
-{% endaddtoblock %}
-{% addtoblock "js" %}
-{{ pixel_urls|json_script:"cookie-consent__pixelurls" }}
-{% endaddtoblock %}
+    </template>
+    <template class="cookie-consent__content">
+        {% for url in pixel_urls %}
+            <img data-consent-src="{{ url }}"
+                 class="visually-hidden"
+                 alt=""
+                 width="1"
+                 height="1" />
+        {% endfor %}
+    </template>
+</div>
 {% addtoblock "js" %}
 {% include "_frontend.html" with entry_point="consentbanner.js" %}
-{% endaddtoblock %}
+{% endaddtoblock "js" %}

--- a/fragdenstaat_de/templates/datashow/base.html
+++ b/fragdenstaat_de/templates/datashow/base.html
@@ -12,62 +12,62 @@
         {% with title=row_label|default:table.label description=row_description|default:table.description|striptags|truncatewords:40 %}
             {% if dataset.theme.image %}
                 {% thumbnail dataset.theme.image 1120x600 crop subject_location=dataset.theme.image.subject_location as image %}
-                {% endif %}
-                {% include "fds_cms/social_meta.html" with title=title description=description image_url=image.url %}
-            {% endwith %}
-        {% else %}
-            {% with title=dataset.name description=dataset.description|striptags|truncatewords:40 %}
-                {% if dataset.theme.image %}
-                    {% thumbnail dataset.theme.image 1120x600 crop subject_location=dataset.theme.image.subject_location as image %}
-                    {% endif %}
-                    {% include "fds_cms/social_meta.html" with title=title description=description image_url=image.url %}
-                {% endwith %}
             {% endif %}
-        {% endblock meta %}
-        {% block body %}
-            <div class="text-bg-secondary">
-                <nav class="container-md" aria-label="breadcrumb">
-                    <ol class="breadcrumb">
-                        <li class="breadcrumb-item">
-                            {# djlint:off D018 #}
-                            <a href="/"> {# djlint:on #}
-                                <i class="fa fa-home"></i>
-                                <span class="visually-hidden">{% trans "Home Page" %}</span>
-                            </a>
-                        </li>
-                        <li class="breadcrumb-item">
-                            {% if dataset %}
-                                {% page_url "datasets" as datasets_url %}
-                                <a href="{{ datasets_url|default:'/daten/' }}">{% translate "Datasets" %}</a>
-                            {% else %}
-                                {% translate "Datasets" %}
-                            {% endif %}
-                        </li>
-                        <li class="breadcrumb-item">
-                            {% if table %}
-                                <a href="{{ dataset.get_absolute_url }}">{{ dataset.name }}</a>
-                            {% else %}
-                                {{ dataset.name }}
-                            {% endif %}
-                        </li>
-                        {% if table and dataset.default_table != table %}
-                            <li class="breadcrumb-item">
-                                {% if row %}
-                                    <a href="{{ table.get_absolute_url }}">{{ table.label }}</a>
-                                {% else %}
-                                    {{ table.label }}
-                                {% endif %}
-                            </li>
+            {% include "fds_cms/social_meta.html" with title=title description=description image_url=image.url %}
+        {% endwith %}
+    {% else %}
+        {% with title=dataset.name description=dataset.description|striptags|truncatewords:40 %}
+            {% if dataset.theme.image %}
+                {% thumbnail dataset.theme.image 1120x600 crop subject_location=dataset.theme.image.subject_location as image %}
+            {% endif %}
+            {% include "fds_cms/social_meta.html" with title=title description=description image_url=image.url %}
+        {% endwith %}
+    {% endif %}
+{% endblock meta %}
+{% block body %}
+    <div class="text-bg-secondary">
+        <nav class="container-md" aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">
+                    {# djlint:off D018 #}
+                    <a href="/"> {# djlint:on #}
+                        <i class="fa fa-home"></i>
+                        <span class="visually-hidden">{% trans "Home Page" %}</span>
+                    </a>
+                </li>
+                <li class="breadcrumb-item">
+                    {% if dataset %}
+                        {% page_url "datasets" as datasets_url %}
+                        <a href="{{ datasets_url|default:'/daten/' }}">{% translate "Datasets" %}</a>
+                    {% else %}
+                        {% translate "Datasets" %}
+                    {% endif %}
+                </li>
+                <li class="breadcrumb-item">
+                    {% if table %}
+                        <a href="{{ dataset.get_absolute_url }}">{{ dataset.name }}</a>
+                    {% else %}
+                        {{ dataset.name }}
+                    {% endif %}
+                </li>
+                {% if table and dataset.default_table != table %}
+                    <li class="breadcrumb-item">
+                        {% if row %}
+                            <a href="{{ table.get_absolute_url }}">{{ table.label }}</a>
+                        {% else %}
+                            {{ table.label }}
                         {% endif %}
-                        {% if row %}<li class="breadcrumb-item">{{ row_label|truncatewords:5 }}</li>{% endif %}
-                    </ol>
-                </nav>
-            </div>
-            {% block app_body %}
-                {% block content %}{% endblock %}
-            {% endblock %}
-        {% endblock %}
-        {% block scripts %}
-            {{ block.super }}
-            <script type="text/javascript" src="{% static 'datashow/js/htmx.min.js' %}"></script>
-        {% endblock %}
+                    </li>
+                {% endif %}
+                {% if row %}<li class="breadcrumb-item">{{ row_label|truncatewords:5 }}</li>{% endif %}
+            </ol>
+        </nav>
+    </div>
+    {% block app_body %}
+        {% block content %}{% endblock %}
+    {% endblock %}
+{% endblock %}
+{% block scripts %}
+    {{ block.super }}
+    <script type="text/javascript" src="{% static 'datashow/js/htmx.min.js' %}"></script>
+{% endblock %}

--- a/fragdenstaat_de/templates/djangocms_picture/email/picture.html
+++ b/fragdenstaat_de/templates/djangocms_picture/email/picture.html
@@ -3,36 +3,36 @@
 {% load markup %}
 {% if object.template == "mjml" %}
     {% thumbnail instance.picture 768x0 crop=scale subject_location=instance.picture.subject_location as img %}
-        <mj-image src="{{ img.url }}"
-        {% if not instance.attributes.alt %}alt="{{ instance.picture.default_alt_text|default:"" }}"{% endif %}
-        {{ instance.attributes_str }}
-        {% if picture_link %}href="{{ picture_link }}"{% endif %}
-        ></mj-image>
-    {% else %}
-        <!--[if gte MSO 9]>
+    <mj-image src="{{ img.url }}"
+    {% if not instance.attributes.alt %}alt="{{ instance.picture.default_alt_text|default:"" }}"{% endif %}
+    {{ instance.attributes_str }}
+    {% if picture_link %}href="{{ picture_link }}"{% endif %}
+    ></mj-image>
+{% else %}
+    <!--[if gte MSO 9]>
   <table width="640">
      <tr>
         <td>
 <![endif]-->
-        <table width="100%" style="max-width:600px;">
+    <table width="100%" style="max-width:600px;">
+        <tr>
+            <td height="60" valign="top">
+                {% if picture_link %}
+                    <a href="{{ picture_link }}" {% if instance.link_target %}target="{{ instance.link_target }}"{% endif %} {{ instance.link_attributes_str }}>
+                    {% endif %}
+                    <img class="emailImage {% if instance.attributes.class %}{{ instance.attributes.class }}{% endif %}" src="{% spaceless %} {% thumbnail instance.picture 768x0 crop=scale subject_location=instance.picture.subject_location %}{% endspaceless %}"{% if not instance.attributes.alt %} alt="{{ instance.picture.default_alt_text|default:"" }}"{% endif %} width="100%" height="" {{ instance.attributes_str }} />
+                    {% if picture_link %}</a>{% endif %}
+            </td>
+        </tr>
+        {% if instance.picture.author %}
             <tr>
-                <td height="60" valign="top">
-                    {% if picture_link %}
-                        <a href="{{ picture_link }}" {% if instance.link_target %}target="{{ instance.link_target }}"{% endif %} {{ instance.link_attributes_str }}>
-                        {% endif %}
-                        <img class="emailImage {% if instance.attributes.class %}{{ instance.attributes.class }}{% endif %}" src="{% spaceless %} {% thumbnail instance.picture 768x0 crop=scale subject_location=instance.picture.subject_location %}{% endspaceless %}"{% if not instance.attributes.alt %} alt="{{ instance.picture.default_alt_text|default:"" }}"{% endif %} width="100%" height="" {{ instance.attributes_str }} />
-                        {% if picture_link %}</a>{% endif %}
-                </td>
+                <td style="text-align: right; font-size: 8px">{{ instance.picture.author|markdown }}</td>
             </tr>
-            {% if instance.picture.author %}
-                <tr>
-                    <td style="text-align: right; font-size: 8px">{{ instance.picture.author|markdown }}</td>
-                </tr>
-            {% endif %}
-        </table>
-        <!--[if gte MSO 9]>
+        {% endif %}
+    </table>
+    <!--[if gte MSO 9]>
       </td>
     </tr>
   </table>
 <![endif]-->
-    {% endif %}
+{% endif %}

--- a/fragdenstaat_de/templates/djangocms_picture/hero/picture.html
+++ b/fragdenstaat_de/templates/djangocms_picture/hero/picture.html
@@ -5,34 +5,34 @@
         <picture>
             {% if not ".svg" in instance.picture.url %}
                 {% thumbnail instance.picture 2000x400 crop subject_location=instance.picture.subject_location as thumb1 %}
-                    {% if thumb1.url %}
-                        <source media="(min-width: 1200px)"
-                                srcset="{{ thumb1.url }}.avif"
-                                type="image/avif" />
-                        <source media="(min-width: 1200px)" srcset="{{ thumb1.url }}" />
-                    {% endif %}
-                    {% thumbnail instance.picture 1200x400 crop subject_location=instance.picture.subject_location as thumb2 %}
-                        {% if thumb2.url %}
-                            <source media="(min-width: 576px)"
-                                    srcset="{{ thumb2.url }}.avif"
-                                    type="image/avif" />
-                            <source media="(min-width: 576px)" srcset="{{ thumb2.url }}" />
-                        {% endif %}
-                        {% thumbnail instance.picture 600x600 crop subject_location=instance.picture.subject_location as thumb3 %}
-                            {% if thumb3.url %}
-                                <source srcset="{{ thumb3.url }}.avif" type="image/avif" />
-                                <source srcset="{{ thumb3.url }}" />
-                            {% endif %}
-                        {% endif %}
-                        <img class="hero-image-img"
-                             {% if instance.attributes.loading %}loading="{{ instance.attributes.loading }}"{% endif %}
-                             width="{{ picture.width|floatformat:"0u" }}"
-                             height="{{ picture.height|floatformat:"0u" }}"
-                             src="{% if thumb1.url %}{{ thumb1.url }}{% else %}{{ instance.picture.url }}{% endif %}"
-                             alt="">
-                    </picture>
-                {% endwith %}
-                {% for plugin in instance.child_plugin_instances %}
-                    {% render_plugin plugin %}
-                {% endfor %}
-            </div>
+                {% if thumb1.url %}
+                    <source media="(min-width: 1200px)"
+                            srcset="{{ thumb1.url }}.avif"
+                            type="image/avif" />
+                    <source media="(min-width: 1200px)" srcset="{{ thumb1.url }}" />
+                {% endif %}
+                {% thumbnail instance.picture 1200x400 crop subject_location=instance.picture.subject_location as thumb2 %}
+                {% if thumb2.url %}
+                    <source media="(min-width: 576px)"
+                            srcset="{{ thumb2.url }}.avif"
+                            type="image/avif" />
+                    <source media="(min-width: 576px)" srcset="{{ thumb2.url }}" />
+                {% endif %}
+                {% thumbnail instance.picture 600x600 crop subject_location=instance.picture.subject_location as thumb3 %}
+                {% if thumb3.url %}
+                    <source srcset="{{ thumb3.url }}.avif" type="image/avif" />
+                    <source srcset="{{ thumb3.url }}" />
+                {% endif %}
+            {% endif %}
+            <img class="hero-image-img"
+                 {% if instance.attributes.loading %}loading="{{ instance.attributes.loading }}"{% endif %}
+                 width="{{ picture.width|floatformat:"0u" }}"
+                 height="{{ picture.height|floatformat:"0u" }}"
+                 src="{% if thumb1.url %}{{ thumb1.url }}{% else %}{{ instance.picture.url }}{% endif %}"
+                 alt="">
+        </picture>
+    {% endwith %}
+    {% for plugin in instance.child_plugin_instances %}
+        {% render_plugin plugin %}
+    {% endfor %}
+</div>

--- a/fragdenstaat_de/templates/djangocms_video/default/_embed_thumbnail.html
+++ b/fragdenstaat_de/templates/djangocms_video/default/_embed_thumbnail.html
@@ -1,0 +1,11 @@
+{% load thumbnail %}
+{% if picture %}
+    {% thumbnail picture "720x0" crop=smart subject_location=picture.subject_location as thumb %}
+    <picture>
+        <source srcset="{{ thumb.url }}.avif" type="image/avif" />
+        <img class="position-absolute top-0 left-0 w-100 h-100 object-fit-cover"
+             loading="lazy"
+             src="{{ thumb.url }}"
+             alt="{{ picture.default_alt_text|default:"" }}" />
+    </picture>
+{% endif %}

--- a/fragdenstaat_de/templates/djangocms_video/default/video_player.html
+++ b/fragdenstaat_de/templates/djangocms_video/default/video_player.html
@@ -1,13 +1,40 @@
-{% load i18n cms_tags %}
+{% load i18n %}
+{% load cms_tags %}
+{% load sekizai_tags %}
+{% load frontendbuild %}
+{% load cookie_consent_tags %}
+{% url 'cookie_consent_status' as status_url %}
+{% url "cookie_consent_cookie_group_list" as manage_cookies %}
+{% url "cookie_consent_accept" varname="youtube" as accept_url %}
+{% url "cookie_consent_decline" varname="youtube" as decline_url %}
 {% if instance.embed_link %}
     {# show iframe if embed_link is provided #}
-    <div class="aspect-ratio aspect-ratio-{% if instance.attributes.ratio %}{{ instance.attributes.ratio }}{% else %}16x9{% endif %}">
-        <iframe src="{{ instance.embed_link }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true"></iframe>
-        {% with disabled=instance.embed_link %}
-            {% for plugin in instance.child_plugin_instances %}
-                {% render_plugin plugin %}
-            {% endfor %}
-        {% endwith %}
+    <div class="cookie-consent"
+         data-status-url="{{ status_url }}"
+         data-cookie-group="youtube"
+         data-accept-url="{{ accept_url }}"
+         data-decline-url="{{ decline_url }}">
+        <template class="cookie-consent__content">
+            <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }}">
+                <iframe data-consent-src="{{ instance.embed_link }}" {{ instance.attributes_str }} frameborder="0" allowfullscreen="true" allow="encrypted-media; picture-in-picture"></iframe>
+            </div>
+        </template>
+        <template class="cookie-consent__message">
+            <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }}">
+                <div class="d-flex flex-column align-items-center justify-content-center text-bg-body-tertiary">
+                    {% page_url "privacy-policy" as privacy %}
+                    <p class="text-center">
+                        {% blocktrans with privacy=privacy %}By playing this video, you agree to YouTube's privacy policy. <a href="{{ privacy }}">Learn more</a>{% endblocktrans %}
+                    </p>
+                    <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
+                </div>
+            </div>
+        </template>
+        <template class="cookie-consent__declined">
+            <p class="text-body-tertiary">
+                {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
+            </p>
+        </template>
     </div>
 {% else %}
     {# render <source> or <track> plugins #}
@@ -26,3 +53,8 @@
     {{ instance.poster }}
     {{ instance.attributes_str }}
 {% endcomment %}
+{% addtoblock "js" %}
+{% if instance.embed_link %}
+    {% include "_frontend.html" with entry_point="consentbanner.js" %}
+{% endif %}
+{% endaddtoblock %}

--- a/fragdenstaat_de/templates/djangocms_video/default/video_player.html
+++ b/fragdenstaat_de/templates/djangocms_video/default/video_player.html
@@ -24,50 +24,50 @@
             <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }} position-relative">
                 {% if instance.poster %}
                     {% thumbnail instance.poster "720x0" crop=smart subject_location=instance.poster.subject_location as thumb %}
-                        <picture>
-                            <source srcset="{{ thumb.url }}.avif" type="image/avif" />
-                            <img class="position-absolute top-0 left-0 w-100 h-100 object-fit-cover"
-                                 loading="lazy"
-                                 src="{{ thumb.url }}"
-                                 alt="{{ picture.default_alt_text|default:"" }}" />
-                        </picture>
-                    {% endif %}
-                    <div class="d-flex flex-column align-items-center justify-content-center text-md-center p-3 {% if instance.poster %}text-bg-gray-900 bg-opacity-90{% else %}text-bg-body-tertiary{% endif %}">
-                        {% page_url "privacy-policy" as privacy %}
-                        <h3>{% trans "We need your consent to show you a YouTube video" %}</h3>
-                        <p>{% blocktrans %}By playing this video, you agree to YouTube's privacy policy.{% endblocktrans %}</p>
-                        <div class="hstack gap-2 justify-content-center">
-                            <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
-                            <a href="{{ privacy }}" class="btn btn-light">{% trans "Learn more" %}</a>
-                        </div>
+                    <picture>
+                        <source srcset="{{ thumb.url }}.avif" type="image/avif" />
+                        <img class="position-absolute top-0 left-0 w-100 h-100 object-fit-cover"
+                             loading="lazy"
+                             src="{{ thumb.url }}"
+                             alt="{{ picture.default_alt_text|default:"" }}" />
+                    </picture>
+                {% endif %}
+                <div class="d-flex flex-column align-items-center justify-content-center text-md-center p-3 {% if instance.poster %}text-bg-gray-900 bg-opacity-90{% else %}text-bg-body-tertiary{% endif %}">
+                    {% page_url "privacy-policy" as privacy %}
+                    <h3>{% trans "We need your consent to show you a YouTube video" %}</h3>
+                    <p>{% blocktrans %}By playing this video, you agree to YouTube's privacy policy.{% endblocktrans %}</p>
+                    <div class="hstack gap-2 justify-content-center">
+                        <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
+                        <a href="{{ privacy }}" class="btn btn-light">{% trans "Learn more" %}</a>
                     </div>
                 </div>
-            </template>
-            <template class="cookie-consent__declined">
-                <p class="text-body-tertiary">
-                    {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
-                </p>
-            </template>
-        </div>
-    {% else %}
-        {# render <source> or <track> plugins #}
-        <video {{ instance.attributes_str }} {% if instance.poster %}poster="{{ instance.poster.url }}"{% endif %}>
-            {% for plugin in instance.child_plugin_instances %}
-                {% render_plugin plugin %}
-            {% endfor %}
-            {% trans "Your browser doesn't support this video format." %}
-        </video>
-    {% endif %}
-    {% comment %}
+            </div>
+        </template>
+        <template class="cookie-consent__declined">
+            <p class="text-body-tertiary">
+                {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
+            </p>
+        </template>
+    </div>
+{% else %}
+    {# render <source> or <track> plugins #}
+    <video {{ instance.attributes_str }} {% if instance.poster %}poster="{{ instance.poster.url }}"{% endif %}>
+        {% for plugin in instance.child_plugin_instances %}
+            {% render_plugin plugin %}
+        {% endfor %}
+        {% trans "Your browser doesn't support this video format." %}
+    </video>
+{% endif %}
+{% comment %}
     # Available variables:
     {{ instance.template }}
     {{ instance.label }}
     {{ instance.embed_link }}
     {{ instance.poster }}
     {{ instance.attributes_str }}
-    {% endcomment %}
-    {% addtoblock "js" %}
-    {% if instance.embed_link %}
-        {% include "_frontend.html" with entry_point="consentbanner.js" %}
-    {% endif %}
+{% endcomment %}
+{% addtoblock "js" %}
+{% if instance.embed_link %}
+    {% include "_frontend.html" with entry_point="consentbanner.js" %}
+{% endif %}
 {% endaddtoblock %}

--- a/fragdenstaat_de/templates/djangocms_video/default/video_player.html
+++ b/fragdenstaat_de/templates/djangocms_video/default/video_player.html
@@ -3,7 +3,7 @@
 {% load sekizai_tags %}
 {% load frontendbuild %}
 {% load cookie_consent_tags %}
-{% load thumbnail %}
+{% load video_player_tags %}
 {% url 'cookie_consent_status' as status_url %}
 {% url "cookie_consent_cookie_group_list" as manage_cookies %}
 {% url "cookie_consent_accept" varname="youtube" as accept_url %}
@@ -22,20 +22,15 @@
         </template>
         <template class="cookie-consent__message">
             <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }} position-relative">
-                {% if instance.poster %}
-                    {% thumbnail instance.poster "720x0" crop=smart subject_location=instance.poster.subject_location as thumb %}
-                    <picture>
-                        <source srcset="{{ thumb.url }}.avif" type="image/avif" />
-                        <img class="position-absolute top-0 left-0 w-100 h-100 object-fit-cover"
-                             loading="lazy"
-                             src="{{ thumb.url }}"
-                             alt="{{ picture.default_alt_text|default:"" }}" />
-                    </picture>
-                {% endif %}
+                {% include "djangocms_video/default/_embed_thumbnail.html" with picture=instance.poster %}
                 <div class="d-flex flex-column align-items-center justify-content-center text-md-center p-3 {% if instance.poster %}text-bg-gray-900 bg-opacity-90{% else %}text-bg-body-tertiary{% endif %}">
                     {% page_url "privacy-policy" as privacy %}
                     <h3>{% trans "We need your consent to show you a YouTube video" %}</h3>
-                    <p>{% blocktrans %}By playing this video, you agree to YouTube's privacy policy.{% endblocktrans %}</p>
+                    <p>
+                        {% with direct_url=instance.embed_link|youtube_url %}
+                            {% blocktrans with direct_url=direct_url %}By playing <a href="{{ direct_url }}" target="_blank">this video</a>, you agree to YouTube's privacy policy.{% endblocktrans %}
+                        {% endwith %}
+                    </p>
                     <div class="hstack gap-2 justify-content-center">
                         <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
                         <a href="{{ privacy }}" class="btn btn-light">{% trans "Learn more" %}</a>
@@ -44,9 +39,17 @@
             </div>
         </template>
         <template class="cookie-consent__declined">
-            <p class="text-body-tertiary">
-                {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
-            </p>
+            <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }} position-relative">
+                {% include "djangocms_video/default/_embed_thumbnail.html" with picture=instance.poster %}
+                <div class="d-flex flex-column align-items-center justify-content-center text-md-center p-3 {% if instance.poster %}text-bg-gray-900 bg-opacity-90{% else %}text-bg-body-tertiary{% endif %}">
+                    <p>
+                        {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
+                    </p>
+                    <a href="{{ instance.embed_link|youtube_url }}"
+                       class="btn btn-primary"
+                       target="_blank">{% trans "Watch on YouTube" %} <i class="fa fa-external-link"></i></a>
+                </div>
+            </div>
         </template>
     </div>
 {% else %}

--- a/fragdenstaat_de/templates/djangocms_video/default/video_player.html
+++ b/fragdenstaat_de/templates/djangocms_video/default/video_player.html
@@ -3,6 +3,7 @@
 {% load sekizai_tags %}
 {% load frontendbuild %}
 {% load cookie_consent_tags %}
+{% load thumbnail %}
 {% url 'cookie_consent_status' as status_url %}
 {% url "cookie_consent_cookie_group_list" as manage_cookies %}
 {% url "cookie_consent_accept" varname="youtube" as accept_url %}
@@ -20,41 +21,53 @@
             </div>
         </template>
         <template class="cookie-consent__message">
-            <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }}">
-                <div class="d-flex flex-column align-items-center justify-content-center text-bg-body-tertiary">
-                    {% page_url "privacy-policy" as privacy %}
-                    <p class="text-center">
-                        {% blocktrans with privacy=privacy %}By playing this video, you agree to YouTube's privacy policy. <a href="{{ privacy }}">Learn more</a>{% endblocktrans %}
-                    </p>
-                    <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
+            <div class="ratio ratio-{{ instance.attributes.ratio|default:"16x9" }} position-relative">
+                {% if instance.poster %}
+                    {% thumbnail instance.poster "720x0" crop=smart subject_location=instance.poster.subject_location as thumb %}
+                        <picture>
+                            <source srcset="{{ thumb.url }}.avif" type="image/avif" />
+                            <img class="position-absolute top-0 left-0 w-100 h-100 object-fit-cover"
+                                 loading="lazy"
+                                 src="{{ thumb.url }}"
+                                 alt="{{ picture.default_alt_text|default:"" }}" />
+                        </picture>
+                    {% endif %}
+                    <div class="d-flex flex-column align-items-center justify-content-center text-md-center p-3 {% if instance.poster %}text-bg-gray-900 bg-opacity-90{% else %}text-bg-body-tertiary{% endif %}">
+                        {% page_url "privacy-policy" as privacy %}
+                        <h3>{% trans "We need your consent to show you a YouTube video" %}</h3>
+                        <p>{% blocktrans %}By playing this video, you agree to YouTube's privacy policy.{% endblocktrans %}</p>
+                        <div class="hstack gap-2 justify-content-center">
+                            <button type="button" class="btn btn-primary cookie-consent__accept">{% translate "Accept" %}</button>
+                            <a href="{{ privacy }}" class="btn btn-light">{% trans "Learn more" %}</a>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </template>
-        <template class="cookie-consent__declined">
-            <p class="text-body-tertiary">
-                {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
-            </p>
-        </template>
-    </div>
-{% else %}
-    {# render <source> or <track> plugins #}
-    <video {{ instance.attributes_str }} {% if instance.poster %}poster="{{ instance.poster.url }}"{% endif %}>
-        {% for plugin in instance.child_plugin_instances %}
-            {% render_plugin plugin %}
-        {% endfor %}
-        {% trans "Your browser doesn't support this video format." %}
-    </video>
-{% endif %}
-{% comment %}
+            </template>
+            <template class="cookie-consent__declined">
+                <p class="text-body-tertiary">
+                    {% blocktrans with manage_cookies=manage_cookies %}You have chosen to not show YouTube videos on our site. <a href="{{ manage_cookies }}">Change cookie preferences</a>{% endblocktrans %}
+                </p>
+            </template>
+        </div>
+    {% else %}
+        {# render <source> or <track> plugins #}
+        <video {{ instance.attributes_str }} {% if instance.poster %}poster="{{ instance.poster.url }}"{% endif %}>
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+            {% trans "Your browser doesn't support this video format." %}
+        </video>
+    {% endif %}
+    {% comment %}
     # Available variables:
     {{ instance.template }}
     {{ instance.label }}
     {{ instance.embed_link }}
     {{ instance.poster }}
     {{ instance.attributes_str }}
-{% endcomment %}
-{% addtoblock "js" %}
-{% if instance.embed_link %}
-    {% include "_frontend.html" with entry_point="consentbanner.js" %}
-{% endif %}
+    {% endcomment %}
+    {% addtoblock "js" %}
+    {% if instance.embed_link %}
+        {% include "_frontend.html" with entry_point="consentbanner.js" %}
+    {% endif %}
 {% endaddtoblock %}

--- a/fragdenstaat_de/theme/templatetags/video_player_tags.py
+++ b/fragdenstaat_de/theme/templatetags/video_player_tags.py
@@ -1,0 +1,20 @@
+import re
+
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def youtube_url(value) -> str | None:
+    # CC BY-SA 3.0 https://stackoverflow.com/a/9102270
+    youtube_re = re.compile(
+        r".*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*"
+    )
+    result = re.match(youtube_re, value)
+
+    if result:
+        return f"https://www.youtube.com/watch?v={result.group(2)}"
+    raise ValueError("Could not parse YouTube URL")

--- a/frontend/javascript/consentbanner.ts
+++ b/frontend/javascript/consentbanner.ts
@@ -1,43 +1,101 @@
 import { Modal } from 'bootstrap'
-import {showCookieBar} from 'django-cookie-consent';
 
-
-const cookieConsentModalTemplateId = "cookie-consent__cookie-bar"
-
-const startConsentCheck = (statusUrl: string) => {
-    let modal: Modal | null = null
-    showCookieBar({
-        statusUrl,
-        templateSelector: `#${cookieConsentModalTemplateId}`,
-        cookieGroupsSelector: '#cookie-consent__cookie-groups',
-        acceptSelector: "#cookie-consent__accept",
-        declineSelector: "#cookie-consent__decline",
-        onShow: () => {
-            modal = new Modal("#cookie-consent__modal")
-            modal.show()
-        },
-        onAccept: () => {
-            modal?.hide()
-            let pixelUrls: string[] = []
-            pixelUrls = JSON.parse(document.getElementById('cookie-consent__pixelurls')?.textContent || '[]');
-            pixelUrls.forEach((url: string) => {
-                const img = document.createElement('img')
-                img.src = url
-                img.height = 1
-                img.width = 1
-                img.style.display = 'none'
-                document.body.appendChild(img)
-            })
-        },
-        onDecline: () => {
-            modal?.hide()
-        },
-    });
+const DEFAULT_FETCH_HEADERS = {
+  'X-Cookie-Consent-Fetch': '1'
 }
 
+document
+  .querySelectorAll<HTMLElement>('.cookie-consent')
+  .forEach(async (container) => {
+    const consentMessage = container
+      .querySelector<HTMLTemplateElement>('.cookie-consent__message')!
+      .content.cloneNode(true) as Element
 
+    let modal: Modal | undefined
 
-const cookieBarTemplate = document.getElementById(cookieConsentModalTemplateId)
-if (cookieBarTemplate !== null) {
-    startConsentCheck(cookieBarTemplate.dataset.cookiestatus!)
-}
+    const accepted = () => {
+      modal?.hide()
+
+      const { content } = container.querySelector<HTMLTemplateElement>(
+        '.cookie-consent__content'
+      )!
+
+      content
+        .querySelectorAll<HTMLElement>('[data-consent-src]')
+        .forEach((el) => {
+          el.setAttribute('src', el.dataset.consentSrc!)
+          el.removeAttribute('data-consent-src')
+        })
+
+      console.log(content)
+
+      container.replaceChildren()
+      container.appendChild(content.cloneNode(true))
+    }
+
+    const declined = () => {
+      modal?.hide()
+
+      const declinedMessage = container
+        .querySelector<HTMLTemplateElement>('.cookie-consent__declined')
+        ?.content.cloneNode(true)
+
+      if (declinedMessage) {
+        container.replaceChildren()
+        container.appendChild(declinedMessage)
+      } else {
+        container.remove()
+      }
+    }
+
+    const group = container.dataset.cookieGroup!
+
+    const status = await fetch(container.dataset.statusUrl!, {
+      credentials: 'same-origin',
+      headers: DEFAULT_FETCH_HEADERS
+    }).then((r) => r.json())
+
+    const postConsentStatus = async (url: string) => {
+      await fetch(url, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: DEFAULT_FETCH_HEADERS
+      })
+    }
+
+    if (status.acceptedCookieGroups.includes(group)) {
+      accepted()
+    } else if (!status.declinedCookieGroups.includes(group)) {
+      let buttonsContainer
+
+      if (consentMessage.firstElementChild?.classList.contains('modal')) {
+        // can't append the entire consentMessage, as that's a document fragment,
+        // and appendChild returns the copied (now empty!) fragment when appending a document fragment
+        const modalEl = document.body.appendChild(
+          consentMessage.firstElementChild
+        )
+        modal = new Modal(modalEl)
+        modal.show()
+        buttonsContainer = modalEl
+      } else {
+        container.appendChild(consentMessage)
+        buttonsContainer = container
+      }
+
+      buttonsContainer
+        .querySelector('.cookie-consent__accept')
+        ?.addEventListener('click', async () => {
+          accepted()
+          await postConsentStatus(container.dataset.acceptUrl!)
+        })
+
+      buttonsContainer
+        .querySelector('.cookie-consent__decline')
+        ?.addEventListener('click', async () => {
+          declined()
+          await postConsentStatus(container.dataset.declineUrl!)
+        })
+    } else {
+      declined()
+    }
+  })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ exclude_lines = ["pragma: no cover"]
 
 [tool.djlint]
 ignore = "T002,T003,H005,H006,H021,H023,H029,H030,H031"
+ignore_blocks = "thumbnail"
 
 [tool.pytest.ini_options]
 DJANGO_CONFIGURATION = "Test"


### PR DESCRIPTION
- video embeds now need user consent
- refactored consentbanner, dropped upstream component. see https://github.com/django-commons/django-cookie-consent/issues/155
- no longer passing cookie status as json data in html, using api request instead. this should allow for better caching.
