### PR TITLE
🔊 Simplify logging config to avoid duplicate log records

### DIFF
--- a/fragdenstaat_de/settings/production.py
+++ b/fragdenstaat_de/settings/production.py
@@ -219,28 +219,25 @@ class FragDenStaat(FragDenStaatBase):
     ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = "froide.helper.search.CelerySignalProcessor"
 
     LOGGING = {
+        "root": {"handlers": ["console"], "level": "WARNING"},
         "loggers": {
-            "": {"handlers": ["console"], "level": "WARNING"},
-            "froide": {"level": "INFO", "propagate": True, "handlers": ["console"]},
+            "froide": {
+                "level": "INFO",
+            },
             "fragdenstaat_de": {
                 "level": "INFO",
-                "propagate": True,
-                "handlers": ["console"],
             },
             "froide_payment": {
                 "level": "INFO",
-                "propagate": True,
-                "handlers": ["console"],
+            },
+            "froide_evidencecollection": {
+                "level": "INFO",
             },
             "sentry.errors": {
-                "handlers": ["console"],
-                "propagate": False,
                 "level": "DEBUG",
             },
             "django.request": {
                 "level": "ERROR",
-                "propagate": True,
-                "handlers": ["console"],
             },
         },
         "disable_existing_loggers": True,
@@ -260,7 +257,6 @@ class FragDenStaat(FragDenStaatBase):
             "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
             "ignore_501": {"()": "fragdenstaat_de.theme.utils.Ignore501Errors"},
         },
-        "root": {"handlers": ["console"], "level": "WARNING"},
     }
     MANAGERS = (("FragDenStaat.de", "mail@fragdenstaat.de"),)
     MEDIA_ROOT = env("DJANGO_MEDIA_ROOT")
@@ -301,7 +297,7 @@ class FragDenStaat(FragDenStaatBase):
 class FragDenStaatDebug(FragDenStaat):
     LOGGING = dict(FragDenStaat.LOGGING)
     LOGGING["disable_existing_loggers"] = False
-    LOGGING["loggers"][""] = {"handlers": ["console"], "level": "DEBUG"}
+    LOGGING["root"] = {"handlers": ["console"], "level": "DEBUG"}
 
 
 class CMSSiteProduction(CMSSiteBase):
@@ -329,50 +325,7 @@ class CMSSiteProduction(CMSSiteBase):
     STATIC_ROOT = env("DJANGO_STATIC_ROOT")
     STATIC_URL = env("STATIC_URL", "https://static.frag-den-staat.de/static/")
 
-    LOGGING = {
-        "loggers": {
-            "": {"handlers": ["console"], "level": "WARNING"},
-            "froide": {"level": "INFO", "propagate": True, "handlers": ["console"]},
-            "fragdenstaat_de": {
-                "level": "INFO",
-                "propagate": True,
-                "handlers": ["console"],
-            },
-            "froide_payment": {
-                "level": "INFO",
-                "propagate": True,
-                "handlers": ["console"],
-            },
-            "sentry.errors": {
-                "handlers": ["console"],
-                "propagate": False,
-                "level": "DEBUG",
-            },
-            "django.request": {
-                "level": "ERROR",
-                "propagate": True,
-                "handlers": ["console"],
-            },
-        },
-        "disable_existing_loggers": True,
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "formatter": "verbose",
-            },
-        },
-        "formatters": {
-            "verbose": {
-                "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
-            }
-        },
-        "version": 1,
-        "filters": {
-            "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
-            "ignore_501": {"()": "fragdenstaat_de.theme.utils.Ignore501Errors"},
-        },
-        "root": {"handlers": ["console"], "level": "WARNING"},
-    }
+    LOGGING = dict(FragDenStaat.LOGGING)
 
     DATABASES = {
         "default": {


### PR DESCRIPTION
### Problem

The current logging setup produces **duplicate log records**. This happens because individual loggers are configured with both `"propagate": True` and explicit `"handlers": ["console"]`.

Example:

```python
LOGGING = {
    "loggers": {
        "": {"handlers": ["console"], "level": "WARNING"},
        "froide": {"level": "INFO", "propagate": True, "handlers": ["console"]},
        "fragdenstaat_de": {
            "level": "INFO",
            "propagate": True,
            "handlers": ["console"],
        },
        ...
    }
}
```

According to the [Python logging docs](https://docs.python.org/3/library/logging.html#logger-objects) (see the infobox on `propagate`), using both leads to duplicate output:

> If you attach a handler to a logger and one or more of its ancestors, it may emit the same record multiple times. In general, you should not need to attach a handler to more than one logger - if you just attach it to the appropriate logger which is highest in the logger hierarchy, then it will see all events logged by all descendant loggers, provided that their propagate setting is left set to True. A common scenario is to attach handlers only to the root logger, and to let propagation take care of the rest.

### Proposed Change

This PR simplifies the logging config to avoid duplication. Since `propagate=True` is the default, loggers only need a level defined.

Example:

```python
"fragdenstaat_de": {
    "level": "INFO",
},
```

### Additional Improvements

- Remove duplicate logger definition for `""` (equivalent to `root`).
- Move `root` config to the top for clarity.
- Clean up duplicate config in `CMSSiteProduction`.
- Add config for `froide-evidencecollection` logger.