### PR TITLE
🐛 handle OverflowError when year/month is out of range

### DIFF
--- a/fragdenstaat_de/fds_blog/views.py
+++ b/fragdenstaat_de/fds_blog/views.py
@@ -121,7 +121,12 @@ class ArticleDetailView(BaseBlogView, DetailView, BreadcrumbView):
     def get_object(self, queryset=None):
         if "article" in self.kwargs:
             return self.kwargs["article"]
-        return super().get_object(queryset)
+
+        try:
+            return super().get_object(queryset)
+        except OverflowError as e:
+            # this can occur if year/month are out of range for date fields
+            raise Http404 from e
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()


### PR DESCRIPTION
Not sure if I like this, feel like Django should maybe handle this in `SingleObjectMixin.get_object`? Having this in such a high-level view seems kind of odd to me.

[Sentry: FRAGDENSTAATDE-11NB](https://sentry.okfn.de/organizations/okfde/issues/34839/events/d62316987917437aa4a92d5c9bceb6b4/)
