### PR TITLE
Security: Stored XSS risk from un-sanitized HTML in InfoTextBox template

### DIFF
--- a/fragdenstaat_de/fds_blog/templates/fds_blog/detailsbox.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/detailsbox.html
@@ -10,7 +10,7 @@
             <span class="inline_detailbox">
                 <a class="inline_detailbox--title">{{ instance.title }}</a>
                 <template>
-                    <div class="inline_detailbox--content">{{ instance.content|safe }}</div>
+                    <div class="inline_detailbox--content">{{ instance.content }}</div>
                 </template>
             </span>
         {% endif %}
@@ -19,7 +19,7 @@
             <summary>
                 <strong>{{ instance.title }}</strong>
             </summary>
-            {{ instance.content|safe }}
+            {{ instance.content }}
         </details>
     {% endif %}
 {% endspaceless %}

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/infotextbox.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/infotextbox.html
@@ -2,4 +2,4 @@
 {% load markup %}
 {% load static %}
 {% load blog_tags %}
-<div class="text-container infotextbox">{{ instance.content|safe }}</div>
+<div class="text-container infotextbox">{{ instance.content }}</div>


### PR DESCRIPTION
## Summary

Security: Stored XSS risk from un-sanitized HTML in InfoTextBox template

## Problem

**Severity**: `High` | **File**: `fragdenstaat_de/fds_blog/templates/fds_blog/infotextbox.html:L5`

The template renders `instance.content` with the `safe` filter, which bypasses Django auto-escaping. If this field can be edited by users with lower trust (or via compromised admin/editor accounts), malicious HTML/JS can be stored and executed in visitors' browsers.

## Solution

Sanitize HTML before rendering (e.g., bleach allowlist) or remove `|safe` and render only trusted markup formats. Restrict edit permissions for this content to highly trusted roles.

## Changes

- `fragdenstaat_de/fds_blog/templates/fds_blog/infotextbox.html` (modified)
- `fragdenstaat_de/fds_blog/templates/fds_blog/detailsbox.html` (modified)