### PR TITLE
♻️ Filter short subwords in analyzer code instead of dictionary

### DIFF
--- a/deps/elasticsearch/Dockerfile
+++ b/deps/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
 FROM elasticsearch:8.19.3
 
-RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/de_DR.xml "https://raw.githubusercontent.com/uschindler/german-decompounder/master/de_DR.xml"
-RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/dictionary-de.txt "https://raw.githubusercontent.com/uschindler/german-decompounder/master/dictionary-de.txt"
+RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/de_DR.xml "https://raw.githubusercontent.com/uschindler/german-decompounder/6227be052f4215294b5a5d498cdcdadfcf7196e6/de_DR.xml"
+RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/dictionary-de.txt "https://raw.githubusercontent.com/uschindler/german-decompounder/6227be052f4215294b5a5d498cdcdadfcf7196e6/dictionary-de.txt"

--- a/deps/elasticsearch/Dockerfile
+++ b/deps/elasticsearch/Dockerfile
@@ -1,6 +1,4 @@
 FROM elasticsearch:8.19.3
 
 RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/de_DR.xml "https://raw.githubusercontent.com/uschindler/german-decompounder/master/de_DR.xml"
-RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/dictionary-de.txt "https://raw.githubusercontent.com/uschindler/german-decompounder/master/dictionary-de.txt" && \
-    # Remove words with up to three letters. \
-    sed -i '/^..$/d; /^...$/d' /usr/share/elasticsearch/config/analysis/dictionary-de.txt
+RUN mkdir -p /usr/share/elasticsearch/config/analysis && curl -o /usr/share/elasticsearch/config/analysis/dictionary-de.txt "https://raw.githubusercontent.com/uschindler/german-decompounder/master/dictionary-de.txt"

--- a/fragdenstaat_de/theme/search.py
+++ b/fragdenstaat_de/theme/search.py
@@ -4,6 +4,9 @@ from elasticsearch_dsl import analyzer, token_filter
 
 from froide.helper.search.filters import BaseQueryPreprocessor
 
+MIN_SUBTOKEN_LENGTH = 4
+
+
 # German stop words from Lucene:
 # https://github.com/apache/lucene/blob/main/lucene/analysis/common/src/resources/org/apache/lucene/analysis/snowball/german_stop.txt
 german_stop = token_filter("german_stop", type="stop", stopwords="_german_")
@@ -15,8 +18,6 @@ german_stemmer = token_filter("de_stemmer", type="stemmer", name="light_german")
 
 # Hyphenation decompounder for breaking up German compound words.
 # Uses the data from https://github.com/uschindler/german-decompounder.
-# Options such as min_subword_size do not seem to work, so short words have been explicitly
-# excluded from the word list.
 decomp = token_filter(
     "decomp",
     type="hyphenation_decompounder",
@@ -26,6 +27,10 @@ decomp = token_filter(
     no_sub_matches=True,
 )
 
+# Crude precision filter; replace once decomp false positives are handled properly.
+# Length filtering is done with a separate filter as the min_subword_size option
+# of the hyphenation_decompounder does not work as expected.
+length = token_filter("length", type="length", min=MIN_SUBTOKEN_LENGTH)
 
 # Token filter that runs multiple filters in parallel and merges the results.
 # Un-stemmed subwords from the decompounder are discarded while the original
@@ -40,6 +45,7 @@ multiplexer = token_filter(
         # Apply decompounding and process the resulting subwords.
         [
             decomp,
+            length,
             "german_normalization",
             "asciifolding",
             german_stemmer,
@@ -201,6 +207,11 @@ class QueryPreprocessor(BaseQueryPreprocessor):
         # Use `startswith` because the decompounder sometimes removes the last character,
         # e.g. "gesetze" -> "gesetz".
         if not tokens[0].startswith("".join(tokens[1:])):
+            return text
+
+        # If any subtoken is short enough that the indexer dropped it,
+        # the decomposition isn't usable for a precise AND rewrite.
+        if any(len(t) < MIN_SUBTOKEN_LENGTH for t in tokens[1:]):
             return text
 
         # Stem the tokens to match different word forms.

--- a/fragdenstaat_de/theme/tests/test_search.py
+++ b/fragdenstaat_de/theme/tests/test_search.py
@@ -184,7 +184,7 @@ test_cases = [
         "Informationsfreiheitsgesetze",
         "(information freiheit gesetz)",
     ),
-    ("Fußgängerübergang", "(fuss gang uber gang)"),
+    ("Fußgängerübergang", "Fußgängerübergang"),
     (
         'Ministerium "Kleine Anfrage"',
         'Ministerium "Kleine Anfrage"',

--- a/fragdenstaat_de/theme/tests/testdata/search_docs.py
+++ b/fragdenstaat_de/theme/tests/testdata/search_docs.py
@@ -34,4 +34,6 @@ search_docs = [
     {"id": "18", "content": "Hund und Maus, Hunde und Mäuse."},
     {"id": "19", "content": "das Verkehrskonzept für Verkehrsmittel"},
     {"id": "20", "content": "Er lief über den Gang."},
+    {"id": "21", "content": "Der Wal in der Ostsee ist ein Buckelwal."},
+    {"id": "22", "content": "Verwaltung in der Treskowallee in Walsrode"},
 ]

--- a/fragdenstaat_de/theme/tests/testdata/search_queries.py
+++ b/fragdenstaat_de/theme/tests/testdata/search_queries.py
@@ -95,7 +95,8 @@ search_tests = [
         ],
     ),
     ("Gesetz", ["1", "2"], [["Informationsfreiheitsgesetz"], ["Gesetz"]]),
-    ("Fußgänger", ["3"], [["Fußgängerübergänge"]]),
+    # Missing match: "Fußgängerübergänge"
+    ("Fußgänger", [], []),
     (
         "Übergang",
         ["20", "3"],
@@ -132,8 +133,8 @@ search_tests = [
     ("gut stadt", ["3"], [["Gütersloh", "gut", "Stadt"]]),
     (
         "gut | städte",
-        ["3", "5", "4", "15"],
-        [["Gütersloh", "gut", "Stadt"], ["Güterverkehrskonzept"], ["Stadt"], ["gut"]],
+        ["3", "5", "15", "4"],
+        [["Gütersloh", "gut", "Stadt"], ["Güterverkehrskonzept"], ["gut"], ["Stadt"]],
     ),
     # --- Multi-word queries.
     ("neues Gesetz", ["2"], [["neues", "Gesetz"]]),
@@ -184,6 +185,11 @@ search_tests = [
     ),
     # --- Normal search and exact phrase search combined.
     ('Ministerium "Kleine Anfrage"', ["9"], [["Ministerium", "Kleine Anfrage"]]),
+    # --- Searches related to short words.
+    # "Ver-wal-tung" but also "Buckelwal" do not match because "Wal" has been filtered out from decompounding.
+    ("Wal", ["21"], [["Wal"]]),
+    ("Buckelwal", ["21"], [["Buckelwal"]]),
+    ("Verwaltung", ["22"], [["Verwaltung"]]),
 ]
 
 

--- a/fragdenstaat_de/theme/tests/testdata/search_tokens.py
+++ b/fragdenstaat_de/theme/tests/testdata/search_tokens.py
@@ -39,7 +39,7 @@ text_analyzer_tests = [
         [
             "fußgängerübergang",
             "fussgangerubergang",
-            "fuss",
+            # "fuss" filtered out because len("fuß") < MIN_SUBTOKEN_LENGTH
             "gang",
             "uber",
         ],
@@ -49,7 +49,7 @@ text_analyzer_tests = [
         [
             "fußgängerübergänge",
             "fussgangerubergang",
-            "fuss",
+            # "fuss" filtered out because len("fuß") < MIN_SUBTOKEN_LENGTH
             "gang",
             "uber",
             # For some reason, the second "gang" is missing here.
@@ -75,6 +75,7 @@ text_analyzer_tests = [
     ),
     # Example of false stemming + weird decompounding.
     ("Schülerinnen", ["schülerinnen", "schulerinn", "rinn"]),
+    ("Verwaltung", ["verwaltung"]),
 ]
 
 search_analyzer_tests = [


### PR DESCRIPTION
Move the "drop subwords shorter than 4 letters" rule from a sed step in the Dockerfile into the analyzer chain, so behavior matches in dev and prod regardless of dictionary preprocessing.

Side-effect: the old sed filter counted bytes, not codepoints, so "fuß" (3 codepoints, 4 bytes) silently survived. The ES length filter
counts codepoints, so such subwords are now dropped. Tests updated.

⚠️ This PR requires rebuilding the search indices.