### PR TITLE
🐛 Show missing donor logout on all donor pages

### DIFF
--- a/fragdenstaat_de/fds_donation/templates/fds_donation/base.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/base.html
@@ -3,3 +3,7 @@
     {{ block.super }}
     <meta name="robots" content="noindex" />
 {% endblock %}
+{% block body %}
+    {{ block.super }}
+    {% include "fds_donation/includes/donor_logout.html" %}
+{% endblock %}

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donor_detail.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donor_detail.html
@@ -134,12 +134,5 @@
             {% include "account/includes/set_password_now.html" %}
         </section>
     {% endif %}
-    {% if request.user != donor.user %}
-        <div class="container my-5">
-            <form action="{% url 'fds_donation:donor-logout' %}" method="post">
-                {% csrf_token %}
-                <button type="submit" class="btn btn-secondary">{% translate "Log out of this donor profile" %}</button>
-            </form>
-        </div>
-    {% endif %}
+    {% include "fds_donation/includes/donor_logout.html" %}
 {% endblock body %}

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/includes/donor_logout.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/includes/donor_logout.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% if donor and request.user != donor.user %}
+    <div class="container my-5">
+        <form action="{% url 'fds_donation:donor-logout' %}" method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-secondary">{% translate "Log out of this donor profile" %}</button>
+        </form>
+    </div>
+{% endif %}


### PR DESCRIPTION
Staff "view on site" for donors without completed donations lands on the donate form which had no simple way to leave the profile before

- Extract logout form into shared donor_logout include
- Render it from fds_donation/base.html for donor pages