### PR TITLE
♿️ Fix heading structure across templates

### DIFF
--- a/fragdenstaat_de/fds_blog/templates/fds_blog/_article_detail.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/_article_detail.html
@@ -72,6 +72,7 @@
     {% endif %}
 {% endblock %}
 {% block article_content %}
+    <h2 class="visually-hidden">{% trans "Article content" %}</h2>
     {% comment %}
         if the article is in edit mode, or the article has manually inserted ads (via cms),
         don't automatically insert ads
@@ -97,14 +98,14 @@
                 {% if not hide_share_links %}
                     <div class="container-lg">
                         <div class="d-md-flex align-items-center">
-                            <h3 class="small text-secondary m-0 me-md-3">{% trans "Share article" %}</h3>
+                            <h2 class="h3 small text-secondary m-0 me-md-3">{% trans "Share article" %}</h2>
                             {% include "fds_blog/includes/share_article.html" with id="article-footer" %}
                         </div>
                     </div>
                 {% endif %}
                 {% if article.tags.count > 0 %}
                     <div class="container-lg d-flex flex-wrap align-items-center mt-3">
-                        <h3 class="small text-secondary m-0">{% trans "Tags" %}</h3>
+                        <h2 class="h3 small text-secondary m-0">{% trans "Tags" %}</h2>
                         <ul class="list-unstyled d-contents">
                             {% for tag in article.tags.all %}
                                 <li class="ms-2">
@@ -121,25 +122,25 @@
             <section class="vstack gap-4">
                 {% if article.credits %}
                     <div class="container-lg">
-                        <h3 class="small text-secondary">{% translate "Credits" %}</h3>
+                        <h2 class="h3 small text-secondary">{% translate "Credits" %}</h2>
                         <div class="border border-2 border-gray-300 p-3 tight-margin">{{ article.credits | linebreaksbr | markdown }}</div>
                     </div>
                 {% endif %}
                 {# Separate authors into two groups: authors_with_profiles & authors_without_profiles #}
                 {% if authors_with_profiles %}
                     <div class="container-lg">
-                        <h3 class="small text-secondary">
+                        <h2 class="h3 small text-secondary">
                             {% blocktranslate trimmed count counter=authors_with_profiles|length %}
                                 About the author
                             {% plural %}
                                 About the authors
                             {% endblocktranslate %}
-                        </h3>
+                        </h2>
                         <div class="row row-cols-1 row-cols-md-2 g-3">
                             {% for author in authors_with_profiles %}
                                 <div class="col d-flex">
                                     <div class="w-100 border border-2 border-gray-300 p-3 tight-margin">
-                                        <h4 class="fs-6">{{ author.get_full_name }}</h4>
+                                        <h3 class="h4 fs-6">{{ author.get_full_name }}</h3>
                                         {{ author.user.profile_text | markdown }}
                                     </div>
                                 </div>
@@ -149,7 +150,7 @@
                 {% endif %}
                 {% if authors_without_profiles %}
                     <div class="container-lg mt-4">
-                        <h3 class="small text-secondary">
+                        <h2 class="h3 small text-secondary">
                             {% if authors_with_profiles %}
                                 {% blocktranslate trimmed count counter=authors_without_profiles|length %}
                                     Further author
@@ -163,7 +164,7 @@
                                     Authors
                                 {% endblocktranslate %}
                             {% endif %}
-                        </h3>
+                        </h2>
                         <ul class="list-unstyled d-md-flex flex-wrap gap-3">
                             {% for author in authors_without_profiles %}<li class="mb-1">{{ author.get_full_name }}</li>{% endfor %}
                         </ul>
@@ -196,13 +197,13 @@
             {% if article_suggestions %}
                 <section>
                     <div class="container-lg">
-                        <h3 class="small text-secondary">
+                        <h2 class="h3 small text-secondary">
                             {% blocktranslate trimmed count counter=article_suggestions|length %}
                                 Related article
                             {% plural %}
                                 Related articles
                             {% endblocktranslate %}
-                        </h3>
+                        </h2>
                         <div class="row g-3 g-lg-4 row-cols-1 row-cols-md-2 row-cols-lg-3">
                             {% for article in article_suggestions %}
                                 {% include "fds_blog/includes/blog_item_short.html" with article=article %}

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/article_list.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/article_list.html
@@ -143,7 +143,7 @@
                 <div class="vstack gap-3">
                     {% block blog_list_items %}
                         {% for article in article_list %}
-                            {% include "fds_blog/includes/blog_item_list.html" with article=article counter=forloop.counter %}
+                            {% include "fds_blog/includes/blog_item_list.html" with article=article counter=forloop.counter heading_tag="h2" %}
                         {% endfor %}
                     {% endblock blog_list_items %}
                     {% block blog_pagination %}

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/includes/_item_meta.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/includes/_item_meta.html
@@ -1,7 +1,12 @@
 {% load i18n %}
 {% load cms_tags %}
 {# size can be sm, lg or xl, which will adjust the heading font size #}
-{% with size=size|default:"lg" %}
+{% with size=size|default:"lg" heading_tag=heading_tag|default:"h3" %}
+    {% if size == "sm" %}
+        {% firstof "h5" as heading_class %}
+    {% elif size == "lg" %}
+        {% firstof "h4" as heading_class %}
+    {% endif %}
     <div>
         {% if hide_date != True %}
             <div class="text-end small text-secondary">
@@ -10,12 +15,12 @@
                 </time>
             </div>
         {% endif %}
-        <h3 class="{% if size == "lg" %}h4{% elif size == "sm" %}h5{% endif %} mt-0 mb-2">
-            {% if article.kicker %}
-                <span class="d-block mb-1 text-body-secondary fw-normal fs-base hyphens-auto">{{ article.kicker }}<span class="visually-hidden">:</span></span>
-            {% endif %}
-            <a href="{{ article.get_absolute_url }}">{{ article.title }}</a>
-        </h3>
+        <{{ heading_tag }} class="{{ heading_class }} mt-0 mb-2">
+        {% if article.kicker %}
+            <span class="d-block mb-1 text-body-secondary fw-normal fs-base hyphens-auto">{{ article.kicker }}<span class="visually-hidden">:</span></span>
+        {% endif %}
+        <a href="{{ article.get_absolute_url }}">{{ article.title }}</a>
+        </{{ heading_tag }}>
     </div>
     <div class="tight-margin">
         {% if article.query_highlight %}

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/includes/_item_meta_brief.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/includes/_item_meta_brief.html
@@ -1,11 +1,13 @@
 {% load i18n %}
 <div class="position-relative">
-    <h3 class="h6 mb-2">
+    {% with heading_tag=heading_tag|default:"h3" %}
+        <{{ heading_tag }} class="h6 mb-2">
         {% if article.kicker %}
             <span class="d-block mb-1 text-body-secondary fw-normal small">{{ article.kicker }}<span class="visually-hidden">:</span></span>
         {% endif %}
         <a href="{{ article.get_absolute_url }}" class="stretched-link">{{ article.title }}</a>
-    </h3>
+        </{{ heading_tag }}>
+    {% endwith %}
     <div class="small text-secondary">
         {% with authors=article.authors.all %}
             {% if authors %}

--- a/fragdenstaat_de/fds_blog/templates/fds_blog/search.html
+++ b/fragdenstaat_de/fds_blog/templates/fds_blog/search.html
@@ -6,13 +6,13 @@
     {{ block.super }}
 {% endblock title %}
 {% block blog_list_header %}
-    <h2>
+    <h1 class="h2">
         {% if form.q.value %}
             {% blocktranslate with q=form.q.value %}Search results for “{{ q }}”{% endblocktranslate %}
         {% else %}
             {% translate "Search articles" %}
         {% endif %}
-    </h2>
+    </h1>
     <form class="row froide-auto-submit row-gap-2"
           role="search"
           method="get"
@@ -40,7 +40,9 @@
     <div class="row my-3">
         <div class="col-6">{% search_alert_form query=form.q.value %}</div>
         <div class="col-6 text-end">
-            {% blocktrans with num=page_obj.paginator.formatted_count count counter=count %}One result{% plural %}{{ num }} results{% endblocktrans %}
+            <h2 class="heading-reset">
+                {% blocktrans with num=page_obj.paginator.formatted_count count counter=count %}One result{% plural %}{{ num }} results{% endblocktrans %}
+            </h2>
         </div>
     </div>
 {% endblock %}

--- a/fragdenstaat_de/fds_cms/templates/cms/base.html
+++ b/fragdenstaat_de/fds_cms/templates/cms/base.html
@@ -35,10 +35,7 @@
         </main>
     {% endblock body_wrapper %}
     {% block footer_container %}
-        <div class="fds-banner" data-banner="bottomBanner" hidden>{% static_alias "bottom_banner" %}</div>
-        <footer class="footer" id="footer">
-            <div class="container">{% static_alias "footer" %}</div>
-        </footer>
+        {% include "snippets/footer.html" %}
     {% endblock footer_container %}
 {% endblock body_tag %}
 {% block scripts %}

--- a/fragdenstaat_de/fds_cms/templates/cms/help_base.html
+++ b/fragdenstaat_de/fds_cms/templates/cms/help_base.html
@@ -15,9 +15,9 @@
                     {% endblock %}
                 </div>
                 <nav class="col-md-4 order-md-first mb-3 mt-3">
-                    <h5>
+                    <h2 class="h5">
                         <a href="{{ help_url }}">{% translate "Topics" %}</a>
-                    </h5>
+                    </h2>
                     <ul class="list-unstyled">
                         {% show_menu 1 100 0 1 %}
                     </ul>

--- a/fragdenstaat_de/fds_cms/templates/fds_cms/search.html
+++ b/fragdenstaat_de/fds_cms/templates/fds_cms/search.html
@@ -10,7 +10,7 @@
 {% endblock %}
 {% block app_body %}
     {% page_attribute "page_title" request.current_page|get_soft_root as base_title %}
-    <h2>{% blocktranslate with title=base_title %}Search in {{ title }}{% endblocktranslate %}</h2>
+    <h1 class="h2">{% blocktranslate with title=base_title %}Search in {{ title }}{% endblocktranslate %}</h1>
     <form class="mb-3" role="search" method="get" action=".">
         <div class="input-group">
             {{ form.q }}
@@ -21,13 +21,13 @@
         </div>
     </form>
     {% if object_list and form.cleaned_data.q %}
-        <p>{% blocktranslate with q=form.q.value %}Results for “{{ q }}”{% endblocktranslate %}</p>
+        <h2 class="heading-reset">{% blocktranslate with q=form.q.value %}Results for “{{ q }}”{% endblocktranslate %}</h2>
         <ol class="list-unstyled">
             {% for object in object_list %}
                 <li>
-                    <h5 class="mt-0 mb-1">
+                    <h3 class="h5 mt-0 mb-1">
                         <a href="{{ object.page.get_absolute_url }}">{{ object.title }}</a>
-                    </h5>
+                    </h3>
                     {% if object.meta_description %}<small>{{ object.meta_description }}</small>{% endif %}
                     {% if object.query_highlight %}<p class="search-highlight">{{ object.query_highlight }}</p>{% endif %}
                 </li>

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donation_complete.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donation_complete.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block app_body %}
-    <h2 class="text-center">{% translate "Thank you for your donation!" %}</h2>
+    <h1 class="h2 text-center">{% translate "Thank you for your donation!" %}</h1>
     <div class="row mt-5 justify-content-center">
         <div class="col-6 col-md-2">
             <img src="{% static 'img/onboarding/confirm-email.svg' %}"
@@ -11,7 +11,7 @@
     </div>
     <div class="row mt-5 justify-content-center">
         <div class="col-md-8 text-center">
-            <h3>{% translate "Please confirm your email address!" %}</h3>
+            <h2 class="h3">{% translate "Please confirm your email address!" %}</h2>
         </div>
     </div>
     <div class="row mb-5 justify-content-center">

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donation_failed.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donation_failed.html
@@ -3,7 +3,7 @@
 {% load cms_tags %}
 {% block app_body %}
     {% page_url "donate" as donate_url %}
-    <h2 class="text-center">{% translate "Donation failed!" %}</h2>
+    <h1 class="h2 text-center">{% translate "Donation failed!" %}</h1>
     <p class="lead">
         {% blocktranslate trimmed %}
             Your donation with your chosen payment provider has not completed successfully.

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donation_form.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donation_form.html
@@ -7,9 +7,9 @@
     <div class="row justify-content-center">
         <div class="col-md-8 col-lg-6">
             {% if has_donation %}
-                <h3>{% translate "Create a new donation" %}</h3>
+                <h1 class="h3">{% translate "Create a new donation" %}</h1>
             {% else %}
-                <h3>{% translate "Donate now" %}</h3>
+                <h1 class="h3">{% translate "Donate now" %}</h1>
             {% endif %}
             {% if recurrences %}
                 <div class="alert alert-warning">

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donor_change_email.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donor_change_email.html
@@ -7,7 +7,7 @@
 {% block app_body %}
     <div class="row justify-content-center">
         <div class="col-8">
-            <h3>{% translate "Update your email address" %}</h3>
+            <h1 class="h3">{% translate "Update your email address" %}</h1>
             {% if object.email %}
                 <p>
                     {% translate "Your current email address is:" %}

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donor_form.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donor_form.html
@@ -7,7 +7,7 @@
 {% block app_body %}
     <div class="row justify-content-center">
         <div class="col-8">
-            <h3>{% translate "Update your donor details" %}</h3>
+            <h1 class="h3">{% translate "Update your donor details" %}</h1>
             <p>{% translate "This is the basis for the donation receipts." %}</p>
             <form method="post" action="">
                 {% csrf_token %}

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/donor_login_link_form.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/donor_login_link_form.html
@@ -6,7 +6,7 @@
 {% block app_body %}
     <div class="row mt-5 justify-content-center">
         <div class="col-md-8 col-lg-6">
-            <h2 class="text-center">{% translate "Get a link to your donor profile!" %}</h2>
+            <h1 class="h2 text-center">{% translate "Get a link to your donor profile!" %}</h1>
             <p>{% translate "Please enter your email address to receive a link to access your donations." %}</p>
             <form action="" method="POST">
                 {% csrf_token %}

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/forms/_donation_form_step2.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/forms/_donation_form_step2.html
@@ -68,30 +68,24 @@
         <div class="row">
             {% if form.contact %}
                 <div class="col-auto col-md-6 flex-fill mt-2">
-                    <div class="card border-primary">
-                        <div class="card-header">
-                            <h4>{{ form.contact.label }}</h4>
-                        </div>
+                    <fieldset class="card border-primary d-block">
+                        <legend class="card-header h4 mb-0 pb-3">{{ form.contact.label }}</legend>
                         <div class="card-body">
                             <p>{% trans "Receive our newsletter about freedom of information in German." %}</p>
                             {% render_field form.contact stacked=True show_label=False %}
                         </div>
-                    </div>
+                    </fieldset>
                 </div>
             {% endif %}
             {% if not request.user.is_authenticated and form.account %}
                 <div class="col-auto col-md-6 flex-fill mt-2">
-                    <div class="card">
-                        <div class="card-header">
-                            <h4>{% trans "Get an account" %}</h4>
-                        </div>
+                    <fieldset class="card d-block">
+                        <legend class="card-header h4 mb-0 pb-3">{% trans "Get an account" %}</legend>
                         <div class="card-body">
-                            <div class="mb-3">
-                                <label>{{ form.account.label }}</label>
-                                {% render_field form.account stacked=True show_label=False %}
-                            </div>
+                            <p>{{ form.account.label }}</p>
+                            {% render_field form.account stacked=True show_label=False %}
                         </div>
-                    </div>
+                    </fieldset>
                 </div>
             {% endif %}
         </div>

--- a/fragdenstaat_de/fds_donation/templates/fds_donation/forms/_donation_quick.html
+++ b/fragdenstaat_de/fds_donation/templates/fds_donation/forms/_donation_quick.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 <div class="quick-payment-container mb-3" hidden>
     {% if not form.quick_payment_only %}
-        <div class="border rounded p-3 mb-3">
-            <h4>{% translate "No time? Donate with one click!" %}</h4>
+        <fieldset class="border rounded p-3 mb-3">
+            <legend class="h4">{% translate "No time? Donate with one click!" %}</legend>
             {% include "froide_payment/payment/quickpayment.html" with amount=form.amount.value interval=form.interval.value %}
-        </div>
+        </fieldset>
     {% else %}
         {% include "froide_payment/payment/quickpayment.html" with amount=form.amount.value interval=form.interval.value %}
     {% endif %}

--- a/fragdenstaat_de/fds_easylang/templates/fds_easylang/base.html
+++ b/fragdenstaat_de/fds_easylang/templates/fds_easylang/base.html
@@ -1,7 +1,6 @@
 {% extends "cms/base.html" %}
 {% load cms_tags %}
 {% load static %}
-{% load djangocms_alias_tags %}
 {% load easylang_tags %}
 {% block body_extra_attributes %}class="easylang"{% endblock %}
 {% block top_block %}
@@ -11,7 +10,5 @@
 {% endblock %}
 {% block footer_container %}
     {% include "fds_easylang/feedback.html" %}
-    <footer class="footer" id="footer">
-        <div class="container">{% static_alias "footer_easylang" %}</div>
-    </footer>
+    {% include "snippets/footer.html" with alias="footer_easylang" hide_banner=True %}
 {% endblock footer_container %}

--- a/fragdenstaat_de/fds_newsletter/templates/fds_newsletter/user_settings.html
+++ b/fragdenstaat_de/fds_newsletter/templates/fds_newsletter/user_settings.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load form_helper %}
 <div id="newsletter" class="card mb-3">
-    <h5 class="card-header">Ihre Newsletter-Einstellungen</h5>
+    <h2 class="h5 card-header">Ihre Newsletter-Einstellungen</h2>
     <div class="card-body">
         <p>Bitte wählen Sie, welche Newsletter Sie erhalten wollen.</p>
         <form method="POST" action="{% url 'newsletter_user_settings' %}">

--- a/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
+++ b/fragdenstaat_de/locale/de/LC_MESSAGES/django.po
@@ -308,6 +308,10 @@ msgstr "Artikel-Schlagworte"
 msgid "Article archive"
 msgstr "Artikel-Archiv"
 
+#: fragdenstaat_de/fds_blog/templates/fds_blog/_article_detail.html
+msgid "Article content"
+msgstr "Artikel-Inhalt"
+
 #: fragdenstaat_de/fds_blog/cms_toolbars.py
 msgid "Article overview"
 msgstr "Artikel-Übersicht"
@@ -1379,6 +1383,10 @@ msgstr "Follow-Mailing"
 #: fragdenstaat_de/fds_cms/models.py
 msgid "Follow template"
 msgstr "Follow Template"
+
+#: fragdenstaat_de/templates/snippets/footer.html
+msgid "Footer"
+msgstr "Fußzeile"
 
 #: fragdenstaat_de/fds_cms/contact.py
 msgid "For example a private email address"

--- a/fragdenstaat_de/templates/base.html
+++ b/fragdenstaat_de/templates/base.html
@@ -12,10 +12,7 @@
     <div class="dropdown-wrapper">{% static_alias "dropdown_banner" %}</div>
 {% endblock %}
 {% block footer_container %}
-    <div class="fds-banner" data-banner="bottomBanner" hidden>{% static_alias "bottom_banner" %}</div>
-    <footer class="footer" id="footer">
-        <div class="container">{% static_alias "footer" %}</div>
-    </footer>
+    {% include "snippets/footer.html" %}
 {% endblock %}
 {% block scripts %}{{ block.super }}{% endblock %}
 {% block below_scripts %}

--- a/fragdenstaat_de/templates/organization/includes/user_card.html
+++ b/fragdenstaat_de/templates/organization/includes/user_card.html
@@ -12,9 +12,9 @@
                 </div>
             {% endif %}
             <div class="flex-grow-1 tight-margin p-3">
-                <h5>
+                <h3 class="h5">
                     <a href="{{ user.get_absolute_url }}">{{ user.get_full_name }}</a>
-                </h5>
+                </h3>
                 {% if user.profile_text %}
                     {% if user.is_staff %}
                         {{ user.profile_text|markdown }}

--- a/fragdenstaat_de/templates/snippets/footer.html
+++ b/fragdenstaat_de/templates/snippets/footer.html
@@ -1,0 +1,13 @@
+{% load djangocms_alias_tags %}
+{% load i18n %}
+{% with alias=alias|default:"footer" %}
+    {% if not hide_banner %}
+        <div class="fds-banner" data-banner="bottomBanner" hidden>{% static_alias "bottom_banner" %}</div>
+    {% endif %}
+    <footer class="footer" id="footer">
+        <div class="container">
+            <h2 class="visually-hidden">{% trans "Footer" %}</h2>
+            {% static_alias alias %}
+        </div>
+    </footer>
+{% endwith %}


### PR DESCRIPTION
Fixes the heading structure across templates, like https://github.com/okfde/froide/pull/1322 which this PR depends on.
  
In two places, visually hidden headings have been added:
  - an `<h2>` in blog articles, because by convention article content uses `<h3>` as its top-level heading, and changing that in all existing articles would be a major effort,
  - an `<h2>` in the footer, so the footer headings are grouped under their own section.
  
Other changes: 
  - The footer is extracted into `snippets/footer.html`, shared by all base templates, so the hidden heading only lives in one place.
  - The blog item partials accept a `heading_tag` parameter (default `h3`), since they are included at different outline depths.
  - On the donation form, the cards and the quick donation box are now `<fieldset>`s with `<legend>`s instead of using headings.
  
**To do after merge:** in the `footer` CMS alias, change the footer headings to `<h3 class="h6">`.